### PR TITLE
feat(servico): orquestra o fechamento do serviço anterior e transição de estado na criação

### DIFF
--- a/backend-app/src/controllers/servicos.controller.ts
+++ b/backend-app/src/controllers/servicos.controller.ts
@@ -1,46 +1,21 @@
 import type { Request, Response } from "express";
-import { Prisma, type FuncaoMembroGuarnicao } from "@prisma/client";
-import { prisma } from "../lib/prisma.js";
-
-type CriarServicoBody = {
-  data: string;
-  membros: Array<{ alunoNumero: number; funcao: FuncaoMembroGuarnicao }>;
-};
+import { Prisma } from "@prisma/client";
+import { CriarServicoSchema, type CriarServicoBody } from "../schemas/servicos.schema.js";
+import { criarNovoServico } from "../services/servicos.service.js";
 
 const PRISMA_CONFLICT_ERRORS: Record<string, string> = {
   P2002: "Já existe um serviço cadastrado para essa data",
   P2003: "Um ou mais membros informados não existem",
 };
 
+// -> Definir o sgt dia 
+// -> setar status FECHADO no serviço que estava EM_ANDAMENTO
+// -> Alterações com status NOVA vão ser passadas para PENDENTE
+
 export const criarServico = async (req: Request, res: Response) => {
   try {
-    const { data, membros } = req.body as Partial<CriarServicoBody>;
-    const parsedDate = new Date(data ?? "");
-
-    if (Number.isNaN(parsedDate.getTime())) {
-      return res.status(400).json({ error: "Data inválida" });
-    }
-
-    if (!Array.isArray(membros) || membros.length === 0) {
-      return res
-        .status(400)
-        .json({ error: "Informe ao menos um membro para o serviço" });
-    }
-
-    const novoServico = await prisma.servico.create({
-      data: {
-        data: parsedDate,
-        membrosGuarnicao: {
-          create: membros.map((m) => ({
-            alunoNumero: m.alunoNumero,
-            funcao: m.funcao,
-          })),
-        },
-      },
-      include: {
-        membrosGuarnicao: true,
-      },
-    });
+    const dadosValidados = CriarServicoSchema.parse(req.body);
+    const novoServico = await criarNovoServico(dadosValidados)
 
     return res.status(201).json(novoServico);
   } catch (err: unknown) {

--- a/backend-app/src/controllers/servicos.controller.ts
+++ b/backend-app/src/controllers/servicos.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from "express";
 import { Prisma } from "@prisma/client";
-import { CriarServicoSchema, type CriarServicoBody } from "../schemas/servicos.schema.js";
-import { criarNovoServico } from "../services/servicos.service.js";
+import { CriarServicoSchema } from "../schemas/servicos.schema.js";
+import { criarNovoServico, listarServicoAtualService, listarServicosService } from "../services/servicos.service.js";
 
 const PRISMA_CONFLICT_ERRORS: Record<string, string> = {
   P2002: "Já existe um serviço cadastrado para essa data",
@@ -32,3 +32,32 @@ export const criarServico = async (req: Request, res: Response) => {
     });
   }
 };
+
+export const listarServicos = async (req: Request, res: Response) => {
+ try{
+     const getServicos = await listarServicosService();
+     res.status(200).json(getServicos);
+   } catch (err: unknown) {
+     console.error("Erro ao listar os Serviços:", err)
+     return res.status(500).json({
+       error: "Erro interno do servidor ao processar a informação"
+     })
+   }
+} 
+
+export const listarServicoAtual = async (req: Request, res: Response) => {
+  try{
+      const getServicoAtual = await listarServicoAtualService();
+      if (!getServicoAtual) {
+       return res.status(404).json({ message: "Nenhum SGT de dia encontrado para o serviço em andamento." });
+     }
+
+      return res.status(200).json(getServicoAtual);
+
+    } catch (err: unknown) {
+      console.error("Erro ao listar o Serviço Atual: ", err)
+      return res.status(500).json({
+        error: "Erro interno do servidor ao processar a informação"
+      })
+    }
+}

--- a/backend-app/src/routes/servicos.routes.ts
+++ b/backend-app/src/routes/servicos.routes.ts
@@ -1,8 +1,10 @@
 import { Router } from "express";
-import { criarServico } from "../controllers/servicos.controller.js";
+import { criarServico, listarServicoAtual, listarServicos } from "../controllers/servicos.controller.js";
 
 const router = Router()
 
 router.post('/', criarServico)
+router.get('/', listarServicos)
+router.get('/atual', listarServicoAtual)
 
 export default router

--- a/backend-app/src/schemas/alunos.schemas.ts
+++ b/backend-app/src/schemas/alunos.schemas.ts
@@ -13,7 +13,7 @@ const stripUndefinedFields = <T extends Record<string, unknown>>(
 };
 
 
-const numeroSchema = z.coerce
+export const numeroSchema = z.coerce
   .number()
   .int("O número deve ser um valor inteiro")
   .min(10000, "O número do aluno deve ter exatamente 5 dígitos")

--- a/backend-app/src/schemas/servicos.schema.ts
+++ b/backend-app/src/schemas/servicos.schema.ts
@@ -1,4 +1,4 @@
-import { FuncaoMembroGuarnicao } from "@prisma/client";
+import { FuncaoMembroGuarnicao, StatusServico } from "@prisma/client";
 import { z } from "zod";
 import {numeroSchema } from "./alunos.schemas.js";
 
@@ -11,7 +11,7 @@ const dataServicoSchema = z.iso.datetime({
       alunoNumero: numeroSchema,
       funcao: z.enum(FuncaoMembroGuarnicao)
     })
-  )
+  ).min(1, "Informe ao menos um membro para o serviço")
 
 export const CriarServicoSchema = z.object({
   data: dataServicoSchema,
@@ -19,3 +19,16 @@ export const CriarServicoSchema = z.object({
 });
 
 export type CriarServicoBody = z.infer<typeof CriarServicoSchema>
+
+export const ServicoAtualSgtDiaSchema = z.object({
+  servicoId: z.string().uuid(),
+  dataServico: z.date(),
+  statusServico: z.enum(StatusServico),
+  numero: z.number().int().positive(),
+  nomeGuerra: z.string().min(1),
+  nomeCompleto: z.string().min(1),
+  anoFormatura: z.number().int(),
+  curso: z.string().nullable(),
+})
+
+export type ServicoAtualSgtDiaDTO = z.infer<typeof ServicoAtualSgtDiaSchema>

--- a/backend-app/src/schemas/servicos.schema.ts
+++ b/backend-app/src/schemas/servicos.schema.ts
@@ -1,0 +1,21 @@
+import { FuncaoMembroGuarnicao } from "@prisma/client";
+import { z } from "zod";
+import {numeroSchema } from "./alunos.schemas.js";
+
+const dataServicoSchema = z.iso.datetime({
+    error: "data no formato inválido: 2026-04-26"
+  }).transform(value => new Date(value))
+
+  const membrosServicoSchema = z.array(
+    z.object({
+      alunoNumero: numeroSchema,
+      funcao: z.enum(FuncaoMembroGuarnicao)
+    })
+  )
+
+export const CriarServicoSchema = z.object({
+  data: dataServicoSchema,
+  membros: membrosServicoSchema
+});
+
+export type CriarServicoBody = z.infer<typeof CriarServicoSchema>

--- a/backend-app/src/services/alunos.service.ts
+++ b/backend-app/src/services/alunos.service.ts
@@ -1,6 +1,6 @@
 import type { Aluno, Prisma } from "@prisma/client"
 import { prisma } from "../lib/prisma.js"
-import type { AtualizarAlunoInput, CriarAlunoInput } from "../schemas/alunos.schemas.js"
+import type { CriarAlunoInput } from "../schemas/alunos.schemas.js"
 
 // helpers
 

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -1,9 +1,8 @@
 import { prisma } from "../lib/prisma.js";
-import type { CriarServicoBody } from "../schemas/servicos.schema.js";
+import { FuncaoMembroGuarnicao } from "@prisma/client";
+import type { CriarServicoBody, ServicoAtualSgtDiaDTO } from "../schemas/servicos.schema.js";
 
 export const criarNovoServico = async (input: CriarServicoBody ) => {
-  const parsedDate = new Date(input.data ?? "")
-
   const servicoCriado = await prisma.$transaction(async (tx) => {
     
     // Primeiro vamos fechar o serviço anterior
@@ -21,7 +20,7 @@ export const criarNovoServico = async (input: CriarServicoBody ) => {
 
     const novoServico = await tx.servico.create({
           data: {
-            data: parsedDate,
+            data: input.data,
             membrosGuarnicao: {
               create: input.membros.map((m) => ({
                 alunoNumero: m.alunoNumero,
@@ -36,4 +35,51 @@ export const criarNovoServico = async (input: CriarServicoBody ) => {
         return novoServico
   }) 
   return servicoCriado
+}
+
+export const listarServicosService = async () => {
+  const servicos = await prisma.servico.findMany({
+    orderBy: {
+      data: 'desc'
+    }
+  })
+  return servicos
+}
+
+export const listarServicoAtualService = async () => {
+  const servicoAtual = await prisma.servico.findFirst({
+    where: { status: 'EM_ANDAMENTO' },
+    include: {
+      membrosGuarnicao: {
+        include: {
+          aluno: true,
+        },
+      },
+    },
+  })
+
+  if (!servicoAtual) {
+    return null
+  }
+
+  const sgtDia = servicoAtual.membrosGuarnicao.find(
+    (membro) => membro.funcao === FuncaoMembroGuarnicao.SGT_DIA,
+  )
+
+  if (!sgtDia) {
+    return null
+  }
+
+  const dto: ServicoAtualSgtDiaDTO = {
+    servicoId: servicoAtual.id,
+    dataServico: servicoAtual.data,
+    statusServico: servicoAtual.status,
+    numero: sgtDia.aluno.numero,
+    nomeGuerra: sgtDia.aluno.nomeGuerra,
+    nomeCompleto: sgtDia.aluno.nomeCompleto,
+    anoFormatura: sgtDia.aluno.anoFormatura,
+    curso: sgtDia.aluno.curso,
+  }
+
+  return dto
 }

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -1,0 +1,22 @@
+import { prisma } from "../lib/prisma.js";
+import type { CriarServicoBody } from "../schemas/servicos.schema.js";
+
+export const criarNovoServico = async (input: CriarServicoBody ) => {
+  const parsedDate = new Date(input.data ?? "")
+
+  const novoServico = await prisma.servico.create({
+        data: {
+          data: parsedDate,
+          membrosGuarnicao: {
+            create: input.membros.map((m) => ({
+              alunoNumero: m.alunoNumero,
+              funcao: m.funcao,
+            })),
+          },
+        },
+        include: {
+          membrosGuarnicao: true,
+        },
+      });
+      return novoServico
+}

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -4,19 +4,36 @@ import type { CriarServicoBody } from "../schemas/servicos.schema.js";
 export const criarNovoServico = async (input: CriarServicoBody ) => {
   const parsedDate = new Date(input.data ?? "")
 
-  const novoServico = await prisma.servico.create({
-        data: {
-          data: parsedDate,
-          membrosGuarnicao: {
-            create: input.membros.map((m) => ({
-              alunoNumero: m.alunoNumero,
-              funcao: m.funcao,
-            })),
+  const servicoCriado = await prisma.$transaction(async (tx) => {
+    
+    // Primeiro vamos fechar o serviço anterior
+    await tx.servico.updateMany({
+      where: { status: 'EM_ANDAMENTO' },
+      data: { status: 'FECHADO' }
+    })
+
+    // As alterações que estavam como novas, vão para pendentes
+    await tx.alteracao.updateMany({
+      where: { status: 'NOVA' },
+      data: { status: 'PENDENTE' }
+    })
+
+
+    const novoServico = await tx.servico.create({
+          data: {
+            data: parsedDate,
+            membrosGuarnicao: {
+              create: input.membros.map((m) => ({
+                alunoNumero: m.alunoNumero,
+                funcao: m.funcao,
+              })),
+            },
           },
-        },
-        include: {
-          membrosGuarnicao: true,
-        },
-      });
-      return novoServico
+          include: {
+            membrosGuarnicao: true,
+          },
+        });
+        return novoServico
+  }) 
+  return servicoCriado
 }

--- a/frontend-app/src/components/layout/Header.tsx
+++ b/frontend-app/src/components/layout/Header.tsx
@@ -1,16 +1,12 @@
-import { buscarSargentoDeDia } from "../../services/alunos.service";
-import { useQuery } from '@tanstack/react-query';
 import { Button } from "../ui/Button";
 import { PlusCircle } from "lucide-react";
 import { useState } from "react";
 import { ModalServico } from "../pages/Dashboard/ModalServico";
+import { useSargentoDiaAtual } from "../../hooks/useSargentoDiaAtual";
 
 export const Header = () => {
 //  vamos puxar da API usando o react Query 
-  const { data: sgtDia, isLoading } = useQuery({
-    queryKey: ['sgtAtual'],
-    queryFn: buscarSargentoDeDia
-  })
+  const { data: sgtDia, isLoading } = useSargentoDiaAtual()
 
   // const nomeSgtDia = "Al 4º Ano Fulano";
   const anoAtual = new Date().getFullYear() % 100;

--- a/frontend-app/src/components/layout/Sidebar.tsx
+++ b/frontend-app/src/components/layout/Sidebar.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { LayoutGrid, FileSearch2, CalendarDays, FileSignature, ShieldCheck, LogOut } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
-import { buscarSargentoDeDia } from '../../services/alunos.service';
-import { useQuery } from '@tanstack/react-query';
+import { useSargentoDiaAtual } from '../../hooks/useSargentoDiaAtual';
 
 // Tipagem simples para os itens de menu
 interface NavItemProps {
@@ -31,10 +30,7 @@ const NavItem: React.FC<NavItemProps> = ({ icon, label, active, to }) => (
 
 export const Sidebar = () => {
   const location = useLocation()
-  const { data: sgtDia } = useQuery({
-    queryKey: ['sgtAtual'],
-    queryFn: buscarSargentoDeDia
-  })
+  const { data: sgtDia } = useSargentoDiaAtual()
   return (
     <aside className="flex h-screen w-64 flex-col bg-slate-950 p-6 text-white fixed left-0 top-0 z-40">
       {/* 1. Logo/Nome do Sistema (Topo) */}
@@ -59,7 +55,7 @@ export const Sidebar = () => {
       <div className="mt-auto border-t border-slate-800 pt-6">
         <div className="flex items-center gap-3 mb-4">
           <div className="flex h-12 w-12 items-center justify-center rounded-full bg-blue-100 text-blue-700 text-xl font-bold">
-            {sgtDia?.nomeGuerra[0]}
+            {sgtDia?.nomeGuerra?.[0] ?? "?"}
           </div>
           <div>
             <p className="font-semibold text-white">{sgtDia?.nomeGuerra}</p>

--- a/frontend-app/src/hooks/useModalServico.tsx
+++ b/frontend-app/src/hooks/useModalServico.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buscarAlunos } from "../services/alunos.service";
 import { criarNovoServico } from "../services/sevicos.service";
+import { SARGENTO_DIA_ATUAL_QUERY_KEY } from "./useSargentoDiaAtual";
 import { useServicoFormState } from "./useServicoFormState";
 
 export const useModalServico = (onClose: () => void) => {
@@ -23,7 +24,7 @@ export const useModalServico = (onClose: () => void) => {
   const mutation = useMutation({
     mutationFn: criarNovoServico,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['servicoAtual'] })
+      queryClient.invalidateQueries({ queryKey: SARGENTO_DIA_ATUAL_QUERY_KEY })
       onClose()
     } 
   })

--- a/frontend-app/src/hooks/useSargentoDiaAtual.ts
+++ b/frontend-app/src/hooks/useSargentoDiaAtual.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { buscarSgtDeDia } from '../services/sevicos.service'
+
+export const SARGENTO_DIA_ATUAL_QUERY_KEY = ['sargentoDiaAtual']
+
+export const useSargentoDiaAtual = () => {
+  return useQuery({
+    queryKey: SARGENTO_DIA_ATUAL_QUERY_KEY,
+    queryFn: buscarSgtDeDia,
+  })
+}

--- a/frontend-app/src/services/alunos.service.ts
+++ b/frontend-app/src/services/alunos.service.ts
@@ -1,22 +1,6 @@
 import type { Aluno } from '../types/aluno.types';
 import { api } from './api';
 
-
-// Vamos pegar apenas o primeiro aluno da lista para testar
-export const buscarSargentoDeDia = async (): Promise<Aluno | null> => {
-  try {
-    const response = await api.get('/alunos');
-    if (response.data && response.data.length > 0) {
-      // console.log(response.data)
-      return response.data[0]; 
-    }
-    return null;
-  } catch (error) {
-    console.error("Erro ao buscar Sargento de Dia:", error);
-    return null;
-  }
-};
-
 export const buscarAlunos = async () => {
   const response = await api.get('/alunos');
   return response.data;

--- a/frontend-app/src/services/alunos.service.ts
+++ b/frontend-app/src/services/alunos.service.ts
@@ -1,4 +1,3 @@
-import type { Aluno } from '../types/aluno.types';
 import { api } from './api';
 
 export const buscarAlunos = async () => {

--- a/frontend-app/src/services/sevicos.service.ts
+++ b/frontend-app/src/services/sevicos.service.ts
@@ -12,3 +12,24 @@ export const criarNovoServico = async (payload: PayloadNovoServico) => {
   const response = await api.post('/servicos', payload);
   return response.data;
 };
+
+export interface ServicoAtualSgtDiaDTO {
+  servicoId: string
+  dataServico: string
+  statusServico: "EM_ANDAMENTO" | "FECHADO"
+  numero: number
+  nomeGuerra: string
+  nomeCompleto: string
+  anoFormatura: number
+  curso: string | null
+}
+
+export const buscarSgtDeDia = async (): Promise<ServicoAtualSgtDiaDTO | null> => {
+  try {
+    const response = await api.get<ServicoAtualSgtDiaDTO>('/servicos/atual');
+    return response.data;
+  } catch (error) {
+    console.error("Erro ao buscar Sargento de Dia:", error);
+    return null;
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2218,37 +2218,24 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
+        "balanced-match": "^1.0.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
-      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -2436,14 +2423,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/backend-app": {
@@ -2505,9 +2492,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3009,9 +2996,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+      "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optional": true,
       "optionalDependencies": {
@@ -3612,16 +3599,16 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -4557,9 +4544,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
-      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4897,9 +4884,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -4923,9 +4910,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -5001,10 +4988,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -5835,9 +5825,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION
## O que foi feito?
Refatoração completa do fluxo de criação de um novo Serviço, extraindo a lógica de negócio para a camada de `Service` e garantindo a integridade dos dados através de uma transação atômica do banco de dados.

## 🛠️ Mudanças Técnicas
* **Transação do Prisma:** A criação do serviço, o fechamento do turno anterior (`EM_ANDAMENTO` -> `FECHADO`) e a transição das alterações (`NOVA` -> `PENDENTE`) agora ocorrem dentro de um único `prisma.$transaction`.
* **Separação de Responsabilidades:** O Controller agora lida estritamente com a requisição HTTP, delegando as regras de negócio para `servicos.service.ts`.
* **Rotas:** Adicionados e mapeados os controllers para as rotas `GET /servicos` e `GET /servicos/atual`.

Closes #2