### PR TITLE
Feat/mobile api setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 /mobile-app/.expo
 mobile-app/expo-env.d.ts
+mobile-app/.env

--- a/mobile-app/app/index.tsx
+++ b/mobile-app/app/index.tsx
@@ -2,12 +2,15 @@ import { TabsHeader } from '@/src/components/layout/TabsHeader';
 import { TopBar } from '@/src/components/layout/TopBar';
 import { ToggleQuartos } from '@/src/components/pages/Alteracoes/toggleQuartos';
 import { ABAS_ALTERACOES } from '@/src/constants/locais';
+import { useAlteracoes } from '@/src/hooks/useAlteracoes';
 import { useState } from 'react';
 import { View, StyleSheet, ScrollView } from 'react-native';
 
 export default function HomeScreen() {
   const [abaAtiva, setAbaAtiva] = useState(ABAS_ALTERACOES[0])
   
+  const { alteracoes } = useAlteracoes()
+
   return (
     <View style={styles.container}>
       <TopBar userNameInitials='LF'/>
@@ -18,6 +21,7 @@ export default function HomeScreen() {
       <ScrollView style={styles.listaQuartos}>
         <ToggleQuartos 
         abaAtiva={abaAtiva}
+        alteracoes={alteracoes}
         />
         
       </ScrollView>

--- a/mobile-app/package-lock.json
+++ b/mobile-app/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/bottom-tabs": "^7.4.0",
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
+        "axios": "^1.15.2",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
         "expo-font": "~14.0.11",
@@ -4277,6 +4278,12 @@
       "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==",
       "license": "MIT"
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4291,6 +4298,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
+      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -4726,7 +4744,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4950,6 +4967,18 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -5271,6 +5300,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5349,7 +5387,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5478,7 +5515,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5525,7 +5561,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5538,7 +5573,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5811,6 +5845,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6910,6 +6945,26 @@
       "integrity": "sha512-3PYnM29RFXwvAN6Pc/scUfkI7RwhQ/xqyLUyPNlXUp9S40zI8nup9tUSrTLSVnWGBN38FNiGWbwZOB6uR4OGdw==",
       "license": "MIT"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontfaceobserver": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/fontfaceobserver/-/fontfaceobserver-2.3.0.tgz",
@@ -6930,6 +6985,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/freeport-async": {
@@ -7042,7 +7113,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7085,7 +7155,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7235,7 +7304,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7305,7 +7373,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7318,7 +7385,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -8850,7 +8916,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10147,6 +10212,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -15,6 +15,7 @@
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
+    "axios": "^1.15.2",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
     "expo-font": "~14.0.11",
@@ -31,17 +32,17 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-worklets": "0.5.1",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "react-native-worklets": "0.5.1"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",
-    "typescript": "~5.9.2",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~10.0.0"
+    "eslint-config-expo": "~10.0.0",
+    "typescript": "~5.9.2"
   },
   "private": true
 }

--- a/mobile-app/src/components/pages/Alteracoes/toggleQuartos.tsx
+++ b/mobile-app/src/components/pages/Alteracoes/toggleQuartos.tsx
@@ -1,22 +1,29 @@
 import { getSetorByAba, MAPEAMENTO_QUARTOS } from "@/src/constants/locais"
 import { ComodoCard } from "./comodoCard"
+import type { Alteracao } from "@/src/types/alteracao.types"
 
 type ToggleQuartosProps = {
   abaAtiva: string
+  alteracoes: Alteracao[] | null
 }
 
-export const ToggleQuartos = ({ abaAtiva }: ToggleQuartosProps) => {
+export const ToggleQuartos = ({ abaAtiva, alteracoes }: ToggleQuartosProps) => {
   const setorChave = getSetorByAba(abaAtiva)
 
   const comodos = MAPEAMENTO_QUARTOS[setorChave]
 
+  
   return (
     comodos.map((comodo) => {
+      const temAlteracaoPendente =  alteracoes?.some(
+        alt => alt.comodo === comodo.id 
+      )
+      const statusLabel = temAlteracaoPendente ? "Pendente" : "Verificado"
       return (
         <ComodoCard
         key={comodo.id}
         nomeComodo={comodo.label}
-        status="Pendente"
+        status={statusLabel}
         onPress={() => console.log('Vai abrir o toggle')}
         /> 
 

--- a/mobile-app/src/hooks/useAlteracoes.ts
+++ b/mobile-app/src/hooks/useAlteracoes.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react"
+import { Alteracao } from "../types/alteracao.types"
+import { fetchAlteracoes } from "../services/alteracao.service"
+
+export const useAlteracoes = () => {
+  const [alteracoes, setAlteracoes] = useState<Alteracao[] | null>([])
+
+  const carregarDados = async () => {
+    const dados = await fetchAlteracoes() 
+    setAlteracoes(dados)
+  }
+
+  useEffect(() => {
+    carregarDados()
+  }, [])
+
+  return { alteracoes, refetch: carregarDados }
+}

--- a/mobile-app/src/services/alteracao.service.ts
+++ b/mobile-app/src/services/alteracao.service.ts
@@ -1,0 +1,15 @@
+import { api } from "./api"
+import type { Alteracao } from "../types/alteracao.types"
+
+export const fetchAlteracoes = async (): Promise<Alteracao[] | null> => {
+  try {
+    const response = await api.get('api/alteracoes')
+    if(response.data) {
+      return response.data
+    }
+    return null;
+  } catch (error) {
+    console.error("Erro ao buscar alterações: ", error)
+    return null
+  }
+}

--- a/mobile-app/src/services/api.ts
+++ b/mobile-app/src/services/api.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const API_URL = process.env.EXPO_PUBLIC_API_URL;
+
+export const api = axios.create({
+  baseURL: API_URL,
+  timeout: 10000, 
+});
+
+api.interceptors.request.use((config) => {
+  console.log(`[API Request] -> ${config.method?.toUpperCase()} ${config.url}`);
+  return config;
+});

--- a/mobile-app/src/types/alteracao.types.ts
+++ b/mobile-app/src/types/alteracao.types.ts
@@ -1,0 +1,17 @@
+import type { Setor } from "../constants/locais"
+
+export interface Alteracao {
+  id: string,
+  descricao: string,
+  local: Setor,
+  fotoUrl: string | null,
+  comodo: string,
+  status: string
+}
+
+export interface CriarAlteracaoInput {
+  descricao: string
+  local: Setor
+  comodo: string
+  fotoUrl: string | null
+}


### PR DESCRIPTION
## 📝 O que foi feito
Este PR finaliza a etapa estática e inicia a integração do Frontend Mobile com o Backend, conectando a tela inicial de Gestão de Alterações à API real.

## 🛠️ Principais mudanças
- **Configuração de Infra:** Adição do `axios`, configuração do `.env` e criação do arquivo `.gitignore` para o mobile.
- **Camada de Serviço e Tipagem:** Criação da base de `services/` e `types/` para padronizar o consumo da API.
- **Hook de Integração:** Criação do `useAlteracoes`, responsável por buscar os dados no backend.
- **UI Dinâmica:** O componente `ToggleQuartos` e a listagem de cards agora reagem aos dados reais da API, alterando os status (Ex: Pendente / Verificado) dinamicamente.

## 🧪 Como testar
1. Certifique-se de que o backend (`localhost:3000`) e o banco de dados (Docker/Postgres na porta 5433) estão rodando.
2. Crie ou atualize o arquivo `.env` na raiz do projeto `mobile-app` com o seu IP local (ex: `EXPO_PUBLIC_API_URL=http://192.168.x.x:3000`).
3. Rode `npx expo start` no projeto mobile e abra o app.
4. Verifique se os status dos quartos mudam conforme os dados retornados pela sua API local.

## ⏭️ Próximos passos
- Criar a visualização dos detalhes das alterações (expansão do card).