### PR TITLE
feat: painel administrativo de configurações e refatoração da edição de alterações

### DIFF
--- a/backend-app/src/controllers/alteracao.controller.ts
+++ b/backend-app/src/controllers/alteracao.controller.ts
@@ -2,13 +2,18 @@ import type { Request, Response } from "express";
 import { ZodError } from "zod";
 import {
 	alteracaoIdParamSchema,
+	atualizarAlteracaoSchema,
 	atualizarStatusAlteracaoSchema,
+	listarAlteracoesQuerySchema,
 	criarAlteracaoSchema,
+	type AtualizarStatusAlteracaoInput,
+	type AtualizarAlteracaoInput,
 } from "../schemas/alteracao.schemas.js";
 import {
+	atualizarAlteracao,
 	atualizarStatusAlteracao,
 	criarAlteracao,
-	listarAlteracoesAtuais,
+	listarAlteracoes,
 } from "../services/alteracao.service.js";
 import { uploadAlteracaoImage } from "../lib/cloudinary.js";
 
@@ -22,12 +27,52 @@ const handleZodError = (res: Response, err: unknown) => {
 	return null;
 };
 
-export const listarAlteracoesPendentes = async (req: Request, res: Response) => {
+type SchemaComParse = {
+	parse: (value: unknown) => unknown;
+};
+
+const responderAtualizacaoDaAlteracao = async (
+	req: Request,
+	res: Response,
+	schema: SchemaComParse,
+	atualizar: (id: string, dados: any) => Promise<unknown>,
+	errorLog: string,
+	errorResposta: string,
+) => {
 	try {
-		const alteracoes = await listarAlteracoesAtuais();
+		const paramsValidados = alteracaoIdParamSchema.parse(req.params);
+		const dadosValidados = schema.parse(req.body);
+
+		const alteracaoAtualizada = await atualizar(paramsValidados.id, dadosValidados);
+
+		return res.status(200).json(alteracaoAtualizada);
+	} catch (err: unknown) {
+		const zodResponse = handleZodError(res, err);
+		if (zodResponse) return zodResponse;
+
+		if (err instanceof Error && err.message === "ALTERACAO_NAO_ENCONTRADA") {
+			return res.status(404).json({
+				error: "Alteração não encontrada",
+			});
+		}
+
+		console.error(errorLog, err);
+		return res.status(500).json({
+			error: errorResposta,
+		});
+	}
+};
+
+export const listarAlteracoesTodas = async (req: Request, res: Response) => {
+	try {
+		const filtrosValidados = listarAlteracoesQuerySchema.parse(req.query);
+		const alteracoes = await listarAlteracoes(filtrosValidados);
 		return res.status(200).json(alteracoes);
 	} catch (err: unknown) {
-		console.error("Erro ao listar alterações pendentes: ", err);
+		const zodResponse = handleZodError(res, err);
+		if (zodResponse) return zodResponse;
+
+		console.error("Erro ao listar alterações: ", err);
 		return res.status(500).json({
 			error: "Erro interno do servidor ao listar alterações",
 		});
@@ -57,31 +102,25 @@ export const criarNovaAlteracao = async (req: Request, res: Response) => {
 };
 
 export const atualizarStatusDaAlteracao = async (req: Request, res: Response) => {
-	try {
-		const paramsValidados = alteracaoIdParamSchema.parse(req.params);
-		const dadosValidados = atualizarStatusAlteracaoSchema.parse(req.body);
+	return responderAtualizacaoDaAlteracao(
+		req,
+		res,
+		atualizarStatusAlteracaoSchema,
+		async (id, dados) => atualizarStatusAlteracao(id, (dados as AtualizarStatusAlteracaoInput).status),
+		"Erro ao atualizar status da alteração: ",
+		"Erro interno do servidor ao atualizar status",
+	);
+};
 
-		const alteracaoAtualizada = await atualizarStatusAlteracao(
-			paramsValidados.id,
-			dadosValidados.status,
-		);
-
-		return res.status(200).json(alteracaoAtualizada);
-	} catch (err: unknown) {
-		const zodResponse = handleZodError(res, err);
-		if (zodResponse) return zodResponse;
-
-		if (err instanceof Error && err.message === "ALTERACAO_NAO_ENCONTRADA") {
-			return res.status(404).json({
-				error: "Alteração não encontrada",
-			});
-		}
-
-		console.error("Erro ao atualizar status da alteração: ", err);
-		return res.status(500).json({
-			error: "Erro interno do servidor ao atualizar status",
-		});
-	}
+export const atualizarDadosDaAlteracao = async (req: Request, res: Response) => {
+return responderAtualizacaoDaAlteracao(
+	req,
+	res,
+	atualizarAlteracaoSchema,
+	async (id, dados) => atualizarAlteracao(id, dados as AtualizarAlteracaoInput),
+	"Erro ao atualizar alteração: ",
+	"Erro interno do servidor ao atualizar alteração",
+);
 };
 
 export const uploadFotoAlteracao = async (req: Request, res: Response) => {

--- a/backend-app/src/controllers/servicos.controller.ts
+++ b/backend-app/src/controllers/servicos.controller.ts
@@ -1,7 +1,8 @@
 import type { Request, Response } from "express";
-import { Prisma } from "@prisma/client";
-import { CriarServicoSchema } from "../schemas/servicos.schema.js";
-import { criarNovoServico, listarServicoAtualService, listarServicosService } from "../services/servicos.service.js";
+import { Prisma, StatusAlteracao } from "@prisma/client";
+import { ZodError } from "zod";
+import { CriarServicoSchema, servicoIdParamSchema, atualizarServicoSchema } from "../schemas/servicos.schema.js";
+import { criarNovoServico, listarServicoAtualService, listarServicosService, atualizarServicoService } from "../services/servicos.service.js";
 
 const PRISMA_CONFLICT_ERRORS: Record<string, string> = {
   P2002: "Já existe um serviço cadastrado para essa data",
@@ -61,3 +62,34 @@ export const listarServicoAtual = async (req: Request, res: Response) => {
       })
     }
 }
+
+export const atualizarServico = async (req: Request, res: Response) => {
+  try {
+    const { id } = servicoIdParamSchema.parse(req.params);
+    const dadosValidados = atualizarServicoSchema.parse(req.body);
+
+    const servicoAtualizado = await atualizarServicoService(id, dadosValidados.status);
+
+    return res.status(200).json(servicoAtualizado);
+  } catch (err: unknown) {
+    if (err instanceof ZodError) {
+      return res.status(400).json({
+        error: "Dados inválidos",
+        details: err.issues,
+      });
+    }
+
+    if (err instanceof Prisma.PrismaClientKnownRequestError) {
+      if (err.code === 'P2025') {
+        return res.status(404).json({
+          error: "Serviço não encontrado",
+        });
+      }
+    }
+
+    console.error("Erro ao atualizar serviço: ", err);
+    return res.status(500).json({
+      error: "Erro interno do servidor ao atualizar serviço",
+    });
+  }
+};

--- a/backend-app/src/routes/alteracoes.routes.ts
+++ b/backend-app/src/routes/alteracoes.routes.ts
@@ -1,17 +1,19 @@
 import { Router } from "express";
 import {
+  atualizarDadosDaAlteracao,
   atualizarStatusDaAlteracao,
   criarNovaAlteracao,
-  listarAlteracoesPendentes,
+  listarAlteracoesTodas,
   uploadFotoAlteracao,
 } from "../controllers/alteracao.controller.js";
 import { uploadImagem } from "../middlewares/upload.middleware.js";
 
 const router = Router();
 
-router.get("/", listarAlteracoesPendentes);
+router.get("/", listarAlteracoesTodas);
 router.post("/", criarNovaAlteracao);
 router.post("/upload", uploadImagem.single("foto"), uploadFotoAlteracao);
+router.patch("/:id", atualizarDadosDaAlteracao);
 router.patch("/:id/status", atualizarStatusDaAlteracao);
 
 export default router;

--- a/backend-app/src/routes/servicos.routes.ts
+++ b/backend-app/src/routes/servicos.routes.ts
@@ -1,10 +1,11 @@
 import { Router } from "express";
-import { criarServico, listarServicoAtual, listarServicos } from "../controllers/servicos.controller.js";
+import { criarServico, listarServicoAtual, listarServicos, atualizarServico } from "../controllers/servicos.controller.js";
 
 const router = Router()
 
 router.post('/', criarServico)
 router.get('/', listarServicos)
 router.get('/atual', listarServicoAtual)
+router.patch('/:id', atualizarServico)
 
 export default router

--- a/backend-app/src/schemas/alteracao.schemas.ts
+++ b/backend-app/src/schemas/alteracao.schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { SetorLocal } from "@prisma/client";
+import { SetorLocal, StatusAlteracao } from "@prisma/client";
 
 export const criarAlteracaoSchema = z.object({
   local: z.enum(SetorLocal),
@@ -15,10 +15,32 @@ export const alteracaoIdParamSchema = z.object({
 });
 
 export const atualizarStatusAlteracaoSchema = z.object({
-  status: z.enum(["NOVA", "PENDENTE", "RESOLVIDA"]),
+  status: z.enum(StatusAlteracao),
 });
 
 export type AtualizarStatusAlteracaoInput = z.infer<typeof atualizarStatusAlteracaoSchema>;
+
+export const listarAlteracoesQuerySchema = z.object({
+  status: z.enum(StatusAlteracao).optional(),
+  local: z.enum(SetorLocal).optional(),
+  comodo: z.string().optional(),
+});
+
+export type ListarAlteracoesQueryInput = z.infer<typeof listarAlteracoesQuerySchema>;
+
+export const atualizarAlteracaoSchema = z
+  .object({
+    descricao: z.string().min(5, "Informe uma descrição mais detalhada").optional(),
+    local: z.enum(SetorLocal).optional(),
+    fotoUrl: z.string().url("URL da foto inválida").nullable().optional(),
+    comodo: z.string().optional(),
+    status: z.enum(StatusAlteracao).optional(),
+  })
+  .refine((dados) => Object.values(dados).some((valor) => valor !== undefined), {
+    message: "Informe ao menos um campo para atualizar",
+  });
+
+export type AtualizarAlteracaoInput = z.infer<typeof atualizarAlteracaoSchema>;
 
 
 

--- a/backend-app/src/schemas/servicos.schema.ts
+++ b/backend-app/src/schemas/servicos.schema.ts
@@ -32,3 +32,13 @@ export const ServicoAtualSgtDiaSchema = z.object({
 })
 
 export type ServicoAtualSgtDiaDTO = z.infer<typeof ServicoAtualSgtDiaSchema>
+
+export const servicoIdParamSchema = z.object({
+  id: z.string().uuid("ID do serviço inválido"),
+});
+
+export const atualizarServicoSchema = z.object({
+  status: z.enum(StatusServico),
+});
+
+export type AtualizarServicoInput = z.infer<typeof atualizarServicoSchema>

--- a/backend-app/src/services/alteracao.service.ts
+++ b/backend-app/src/services/alteracao.service.ts
@@ -1,6 +1,10 @@
 import type { Alteracao } from "@prisma/client"
 import { prisma } from "../lib/prisma.js"
-import type { CriarAlteracaoInput } from "../schemas/alteracao.schemas.js"
+import type {
+  AtualizarAlteracaoInput,
+  CriarAlteracaoInput,
+  ListarAlteracoesQueryInput,
+} from "../schemas/alteracao.schemas.js"
 
 
 export const criarAlteracao = async (data: CriarAlteracaoInput): Promise<Alteracao> => {
@@ -24,14 +28,16 @@ export const criarAlteracao = async (data: CriarAlteracaoInput): Promise<Alterac
   return alteracaoNova
 }
 
-export const listarAlteracoesAtuais = async (): Promise<Alteracao[]> => {
-
+export const listarAlteracoes = async (
+  filtros: ListarAlteracoesQueryInput = {},
+): Promise<Alteracao[]> => {
   const alteracoes = await prisma.alteracao.findMany({
     where: {
-      status: {
-        in: ['PENDENTE', 'NOVA' ]
-      },
-    }
+      ...(filtros.status ? { status: filtros.status } : {}),
+      ...(filtros.local ? { local: filtros.local } : {}),
+      ...(filtros.comodo ? { comodo: filtros.comodo } : {}),
+    },
+    orderBy: { criadoEm: "desc" },
   })
 
   return alteracoes
@@ -62,5 +68,28 @@ export const atualizarStatusAlteracao = async (
   return await prisma.alteracao.update({
     where: { id },
     data: { status },
+  })
+}
+
+export const atualizarAlteracao = async (
+  id: string,
+  data: AtualizarAlteracaoInput,
+): Promise<Alteracao> => {
+  const alteracaoExistente = await prisma.alteracao.findUnique({
+    where: { id },
+    select: { id: true },
+  })
+
+  if (!alteracaoExistente) {
+    throw new Error("ALTERACAO_NAO_ENCONTRADA")
+  }
+
+  const dadosParaAtualizacao = Object.fromEntries(
+    Object.entries(data).filter(([, valor]) => valor !== undefined),
+  )
+
+  return prisma.alteracao.update({
+    where: { id },
+    data: dadosParaAtualizacao,
   })
 }

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -83,3 +83,15 @@ export const listarServicoAtualService = async () => {
 
   return dto
 }
+
+export const atualizarServicoService = async (
+  servicoId: string,
+  status: 'EM_ANDAMENTO' | 'FECHADO'
+) => {
+  const servicoAtualizado = await prisma.servico.update({
+    where: { id: servicoId },
+    data: { status },
+  })
+
+  return servicoAtualizado
+}

--- a/frontend-app/src/App.tsx
+++ b/frontend-app/src/App.tsx
@@ -6,6 +6,7 @@ import { MainLayout } from './layouts/MainComponent'
 import { AlteracoesPage } from './pages/Alteracoes'
 import { EscalaPage } from './pages/Escala'
 import { SpedPage } from './pages/Sped'
+import { ConfiguracoesPage } from './pages/Configuracoes'
 
 function App() {
 
@@ -19,6 +20,7 @@ function App() {
       <Route path='/alteracoes' element={<AlteracoesPage />} />
       <Route path='/escala' element={<EscalaPage />} />
       <Route path='/sped' element={<SpedPage />} />
+      <Route path='/configuracoes' element={<ConfiguracoesPage />} />
     </Route>
   </Routes>
   )

--- a/frontend-app/src/components/layout/Sidebar.tsx
+++ b/frontend-app/src/components/layout/Sidebar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { LayoutGrid, FileSearch2, CalendarDays, FileSignature, ShieldCheck, LogOut } from 'lucide-react';
+import { LayoutGrid, FileSearch2, CalendarDays, FileSignature, ShieldCheck, LogOut, Settings } from 'lucide-react';
 import { Link, useLocation } from 'react-router-dom';
 import { useSargentoDiaAtual } from '../../hooks/useSargentoDiaAtual';
 
@@ -50,6 +50,7 @@ export const Sidebar = () => {
         <NavItem to='/alteracoes' icon={<FileSearch2 className="h-6 w-6" />} label="Alterações" active={location.pathname === '/alteracoes'}/>
         <NavItem to='/escala' icon={<CalendarDays className="h-6 w-6" />} label="Escala" active={location.pathname === '/escala'}/>
         <NavItem to='/sped' icon={<FileSignature className="h-6 w-6" />} label="SPED" active={location.pathname === '/sped'}/>
+        <NavItem to='/configuracoes' icon={<Settings className="h-6 w-6" />} label="Configurações" active={location.pathname === '/configuracoes'}/>
       </nav>
 
       <div className="mt-auto border-t border-slate-800 pt-6">

--- a/frontend-app/src/components/pages/Alteracoes/DetalhesAlteracao.tsx
+++ b/frontend-app/src/components/pages/Alteracoes/DetalhesAlteracao.tsx
@@ -1,0 +1,68 @@
+import { PencilLine } from "lucide-react"
+import type { Alteracao } from "../../../types/alterecao.types"
+
+type DetalhesAlteracaoProps = {
+  alteracao: Alteracao
+  abrirModalEdicaoAlteracao: (alteracao: Alteracao) => void
+  handleResolverAlteracao: (id: string) => Promise<void>
+}
+
+export const DetalhesAlteracao = ({ alteracao, abrirModalEdicaoAlteracao, handleResolverAlteracao }: DetalhesAlteracaoProps) => {
+  return (
+    <div key={alteracao.id} className="flex gap-6">
+      <div className="w-40 h-40 bg-slate-200 rounded-lg flex items-center justify-center text-slate-400 text-sm font-medium shrink-0 overflow-hidden">
+        {alteracao.fotoUrl ? (
+          <img
+            src={alteracao.fotoUrl}
+            alt="Foto da alteração"
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          "80 x 80"
+        )}
+      </div>
+
+      {/* Dados da Alteração */}
+      <div className="flex flex-col gap-3">
+        <p className="text-slate-700 font-medium">{alteracao.descricao}</p>
+
+        <div className="flex flex-col gap-3">
+          
+          <button
+            className="px-4 py-1.5 border border-slate-200 text-slate-600 text-sm font-medium rounded-lg hover:bg-slate-50 transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              abrirModalEdicaoAlteracao(alteracao)
+            }}
+          >
+            <span className="inline-flex items-center gap-2">
+              <PencilLine size={16} /> Editar
+            </span>
+          </button>
+          <div className="flex gap-4">
+            <label className="flex items-center gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span className="text-sm text-slate-600">Alteração Verificada</span>
+            </label>
+  
+            <div>
+              <button
+                className="mt-2 px-4 py-1.5 border-2 border-emerald-500 text-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-50 transition-colors"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void handleResolverAlteracao(alteracao.id)
+                }}
+              >
+                Alteração Resolvida
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  )
+}

--- a/frontend-app/src/components/pages/Alteracoes/ModalAddAlteracao.tsx
+++ b/frontend-app/src/components/pages/Alteracoes/ModalAddAlteracao.tsx
@@ -1,8 +1,16 @@
 import { Plus, X } from "lucide-react"
+import { useEffect } from "react"
 import { Button } from "../../ui/Button"
 import { Input } from "../../ui/Input"
 import { useModalAlteracao } from "../../../hooks/useModalAlteracao"
-import { getLabelComodo, LABEL_SETOR, type Setor } from "../../../constants/locais"
+import {
+  getLabelComodo,
+  LABEL_SETOR,
+  MAPEAMENTO_QUARTOS,
+  ORDEM_SETORES,
+  type Setor,
+} from "../../../constants/locais"
+import type { Alteracao } from "../../../types/alterecao.types"
 
 // centralizar a interface -> assim como centralizar a componente de modal pra deixar padrão
 interface ModalProps {
@@ -10,15 +18,47 @@ interface ModalProps {
   onClose: () => void
   local: Setor
   comodo: string
-  onCreated?: () => void
+  alteracao?: Alteracao | null
+  onSaved?: () => void
 }
 
-export const ModalAddAlteracao = ({ isOpen, onClose, local, comodo, onCreated }: ModalProps) => {
+export const ModalAddAlteracao = ({
+  isOpen,
+  onClose,
+  local,
+  comodo,
+  alteracao,
+  onSaved,
+}: ModalProps) => {
   
   const {
-    handleSubmit, descricao, setDescricao, fileInputRef, setArquivo,
-    isSubmitting, erro, handleClose, previewUrl
-  } = useModalAlteracao({ onClose, local, comodo, onCreated })
+    handleSubmit,
+    descricao,
+    setDescricao,
+    localSelecionado,
+    setLocalSelecionado,
+    comodoSelecionado,
+    setComodoSelecionado,
+    statusSelecionado,
+    setStatusSelecionado,
+    isEdicao,
+    fileInputRef,
+    setArquivo,
+    isSubmitting,
+    erro,
+    handleClose,
+    previewUrl,
+    fotoAtualUrl,
+  } = useModalAlteracao({ onClose, local, comodo, alteracao, onSaved })
+
+  useEffect(() => {
+    if (!isEdicao) return
+
+    const comodosDaLocalSelecionada = MAPEAMENTO_QUARTOS[localSelecionado] ?? []
+    if (!comodosDaLocalSelecionada.some((item) => item.id === comodoSelecionado) && comodosDaLocalSelecionada[0]) {
+      setComodoSelecionado(comodosDaLocalSelecionada[0].id)
+    }
+  }, [comodoSelecionado, isEdicao, localSelecionado, setComodoSelecionado])
 
 
   if(!isOpen) return null 
@@ -30,8 +70,61 @@ export const ModalAddAlteracao = ({ isOpen, onClose, local, comodo, onCreated }:
           <X size={24} />
         </Button>
 
-        <p className="text-sm text-slate-500">Local: <strong>{LABEL_SETOR[local]}</strong></p>
-        <p className="text-sm text-slate-500 mb-3">Cômodo: <strong>{getLabelComodo(comodo)}</strong></p>
+        <p className="text-xl font-semibold text-slate-900 mb-1">
+          {isEdicao ? "Editar alteração" : "Criar alteração"}
+        </p>
+
+        {isEdicao ? (
+          <div className="grid gap-4 md:grid-cols-3 mb-3">
+            <label className="block">
+              <span className="mb-2 block text-sm font-medium text-slate-900">Local</span>
+              <select
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                value={localSelecionado}
+                onChange={(event) => setLocalSelecionado(event.target.value as Setor)}
+              >
+                {ORDEM_SETORES.map((setor) => (
+                  <option key={setor} value={setor}>
+                    {LABEL_SETOR[setor]}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="mb-2 block text-sm font-medium text-slate-900">Cômodo</span>
+              <select
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                value={comodoSelecionado}
+                onChange={(event) => setComodoSelecionado(event.target.value)}
+              >
+                {(MAPEAMENTO_QUARTOS[localSelecionado] ?? []).map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block">
+              <span className="mb-2 block text-sm font-medium text-slate-900">Status</span>
+              <select
+                className="w-full rounded-xl border border-slate-300 bg-white px-4 py-3 text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/20"
+                value={statusSelecionado}
+                onChange={(event) => setStatusSelecionado(event.target.value as typeof statusSelecionado)}
+              >
+                <option value="NOVA">Nova</option>
+                <option value="PENDENTE">Pendente</option>
+                <option value="RESOLVIDA">Resolvida</option>
+              </select>
+            </label>
+          </div>
+        ) : (
+          <>
+            <p className="text-sm text-slate-500">Local: <strong>{LABEL_SETOR[local]}</strong></p>
+            <p className="text-sm text-slate-500 mb-3">Cômodo: <strong>{getLabelComodo(comodo)}</strong></p>
+          </>
+        )}
       
         <Input 
         label="Descrição"
@@ -57,12 +150,12 @@ export const ModalAddAlteracao = ({ isOpen, onClose, local, comodo, onCreated }:
             leftIcon={<Plus />}
             onClick={() => fileInputRef.current?.click()}
           >
-            Adicionar Foto
+            {isEdicao ? "Alterar foto" : "Adicionar Foto"}
           </Button>
 
-          {previewUrl && (
+          {(previewUrl || fotoAtualUrl) && (
             <img 
-              src={previewUrl}
+              src={previewUrl ?? fotoAtualUrl ?? ""}
               className="h-40 w-40"
             />
             
@@ -80,7 +173,7 @@ export const ModalAddAlteracao = ({ isOpen, onClose, local, comodo, onCreated }:
         disabled={isSubmitting}
         className="mt-6"
         >
-          Criar Alteração
+          {isEdicao ? "Salvar Alteração" : "Criar Alteração"}
         </Button>
 
 

--- a/frontend-app/src/components/pages/Alteracoes/toggleQuarto.tsx
+++ b/frontend-app/src/components/pages/Alteracoes/toggleQuarto.tsx
@@ -1,8 +1,9 @@
-import { ChevronDown, ChevronRight, Plus } from "lucide-react";
+import {  ChevronDown, ChevronRight, Plus } from "lucide-react";
 import type { Comodo, Setor } from "../../../constants/locais";
 import type { Alteracao } from "../../../types/alterecao.types";
 import { useToggleQuarto } from "../../../hooks/useToggleQuarto";
 import { ModalAddAlteracao } from "./ModalAddAlteracao";
+import { DetalhesAlteracao } from "./DetalhesAlteracao";
 
 interface ToggleQuartoProps {
   comodos: Comodo[];
@@ -12,21 +13,27 @@ interface ToggleQuartoProps {
 }
 
 export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQuartoProps) => {
+  
   const {
     quartosExpandidos,
     isModalOpen,
     comodoSelecionado,
+    alteracaoSelecionada,
     toggleQuarto,
     abrirModalAlteracao,
+    abrirModalEdicaoAlteracao,
     fecharModalAlteracao,
+    handleResolverAlteracao,
   } = useToggleQuarto(comodos[0]?.id)
 
   return (
     <>
       {comodos.map((comodo) => {
         const isExpandido = quartosExpandidos.includes(comodo.id);
-        const alteracoesComodo = alteracoes.filter((item) => item.comodo === comodo.id);
-        const status = alteracoesComodo.length > 0 ? "Pendente" : "Verificado";
+        const alteracoesComodo = alteracoes.filter((item) => item.comodo === comodo.id && item.status !== "RESOLVIDA");
+        const status = alteracoesComodo.some((item) => item.status !== "RESOLVIDA")
+          ? "Pendente"
+          : "Verificado";
 
         return (
           <div
@@ -44,9 +51,6 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
                 </span>
                 <span className="font-semibold text-slate-800">{comodo.label}</span>
 
-                {/* da pra transformar em component em /alteracao */}
-                {/* lógica vai ser quando se criar um serviço por padrão as alterações não terão sidos verificadas e ao verificar todas as alterações de um quarto ou qlqr recinto o status muda */}
-                {/* Salvar em algum cantos os diferentes recintos de cada alojamento */}
                 <span
                   className={`px-2.5 py-1 text-xs font-medium rounded-md ${
                     status === "Verificado"
@@ -58,9 +62,7 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
                 </span>
               </div>
 
-              {/* Botão de Adicionar Alteração */}
               <button
-                // O e.stopPropagation evita que o clique no botão abra/feche o toggle
                 onClick={(e) => {
                   e.stopPropagation();
                   abrirModalAlteracao(comodo.id)
@@ -79,38 +81,11 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
                 )}
 
                 {alteracoesComodo.map((alteracao) => (
-                  <div key={alteracao.id} className="flex gap-6">
-                    <div className="w-40 h-40 bg-slate-200 rounded-lg flex items-center justify-center text-slate-400 text-sm font-medium shrink-0 overflow-hidden">
-                      {alteracao.fotoUrl ? (
-                        <img
-                          src={alteracao.fotoUrl}
-                          alt="Foto da alteração"
-                          className="w-full h-full object-cover"
-                        />
-                      ) : (
-                        "80 x 80"
-                      )}
-                    </div>
-
-                    {/* Dados da Alteração */}
-                    <div className="flex flex-col gap-3">
-                      <p className="text-slate-700 font-medium">{alteracao.descricao}</p>
-
-                      <label className="flex items-center gap-2 cursor-pointer">
-                        <input
-                          type="checkbox"
-                          className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
-                        />
-                        <span className="text-sm text-slate-600">Alteração Verificada</span>
-                      </label>
-
-                      <div>
-                        <button className="mt-2 px-4 py-1.5 border-2 border-emerald-500 text-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-50 transition-colors">
-                          Alteração Resolvida
-                        </button>
-                      </div>
-                    </div>
-                  </div>
+                  <DetalhesAlteracao 
+                    alteracao={alteracao} 
+                    abrirModalEdicaoAlteracao={abrirModalEdicaoAlteracao}
+                    handleResolverAlteracao={handleResolverAlteracao}
+                  />
                 ))}
               </div>
             )}
@@ -122,7 +97,8 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
        onClose={fecharModalAlteracao}
        local={setor}
        comodo={comodoSelecionado ?? ""}
-       onCreated={onCreated}
+       alteracao={alteracaoSelecionada}
+       onSaved={onCreated}
       />
     </>
   );

--- a/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
@@ -1,0 +1,116 @@
+import { useState } from 'react'
+import { useConfiguracoes } from '../../../hooks/useConfiguracoes'
+import { Button } from '../../ui/Button'
+import { Input } from '../../ui/Input'
+import { ModalAddAlteracao } from '../Alteracoes/ModalAddAlteracao'
+import type { Alteracao } from '../../../types/alterecao.types'
+
+export const AlteracoesConfiguracoes = () => {
+  const {
+    alteracoes,
+    isLoadingAlteracoes,
+    isErrorAlteracoes,
+  } = useConfiguracoes()
+
+  const [alteracaoSelecionada, setAlteracaoSelecionada] = useState<Alteracao | null>(null)
+  const [filtro, setFiltro] = useState('')
+
+  const alteracoesFiltradas = alteracoes.filter((alt) =>
+    alt.descricao.toLowerCase().includes(filtro.toLowerCase()) ||
+    alt.local.toLowerCase().includes(filtro.toLowerCase()) ||
+    alt.comodo.toLowerCase().includes(filtro.toLowerCase())
+  )
+
+  return (
+    <div className="space-y-4">
+      {/* Filtro */}
+      <Input
+        placeholder="Filtrar por descrição, local ou cômodo..."
+        value={filtro}
+        onChange={(e) => setFiltro(e.target.value)}
+      />
+
+      {/* Status */}
+      {isLoadingAlteracoes && <p className="text-slate-600">Carregando alterações...</p>}
+      {isErrorAlteracoes && <p className="text-red-600">Erro ao carregar alterações</p>}
+
+      {/* Tabela */}
+      {!isLoadingAlteracoes && !isErrorAlteracoes && (
+        <div className="overflow-x-auto rounded-lg border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Descrição
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Local
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Cômodo
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Ações
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {alteracoesFiltradas.map((alteracao) => (
+                <tr key={alteracao.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-6 py-4 text-slate-900">
+                    <p className="line-clamp-2">{alteracao.descricao}</p>
+                  </td>
+                  <td className="px-6 py-4 text-slate-900">{alteracao.local}</td>
+                  <td className="px-6 py-4 text-slate-900">{alteracao.comodo}</td>
+                  <td className="px-6 py-4">
+                    <span
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                        alteracao.status === 'NOVA'
+                          ? 'bg-blue-100 text-blue-800'
+                          : alteracao.status === 'PENDENTE'
+                            ? 'bg-yellow-100 text-yellow-800'
+                            : 'bg-green-100 text-green-800'
+                      }`}
+                    >
+                      {alteracao.status}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => setAlteracaoSelecionada(alteracao)}
+                    >
+                      Editar
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {alteracoesFiltradas.length === 0 && (
+            <div className="px-6 py-8 text-center text-slate-600">
+              {alteracoes.length === 0 ? 'Nenhuma alteração encontrada' : 'Nenhuma alteração corresponde ao filtro'}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Modal de Edição */}
+      {alteracaoSelecionada && (
+        <ModalAddAlteracao
+          isOpen={true}
+          onClose={() => setAlteracaoSelecionada(null)}
+          local={alteracaoSelecionada.local}
+          comodo={alteracaoSelecionada.comodo}
+          alteracao={alteracaoSelecionada}
+          onSaved={() => setAlteracaoSelecionada(null)}
+        />
+      )}
+    </div>
+  )
+}

--- a/frontend-app/src/components/pages/Configuracoes/ServicosConfiguracoes.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/ServicosConfiguracoes.tsx
@@ -1,0 +1,112 @@
+import { useState } from 'react'
+import { useConfiguracoes } from '../../../hooks/useConfiguracoes'
+import { Button } from '../../ui/Button'
+import { Input } from '../../ui/Input'
+import { ModalServico } from '../Dashboard/ModalServico'
+
+interface Servico {
+  id: string
+  data: string
+  status: 'EM_ANDAMENTO' | 'FECHADO'
+  membros?: { alunoNumero: number; funcao: string }[]
+}
+
+export const ServicosConfiguracoes = () => {
+  const {
+    servicos,
+    isLoadingServicos,
+    isErrorServicos,
+  } = useConfiguracoes()
+
+  const [servicoSelecionado, setServicoSelecionado] = useState<Servico | null>(null)
+  const [filtro, setFiltro] = useState('')
+
+  const servicosFiltrados = (servicos as Servico[]).filter((srv) => {
+    const data = new Date(srv.data).toLocaleDateString('pt-BR')
+    return data.includes(filtro) || srv.status.toLowerCase().includes(filtro.toLowerCase())
+  })
+
+  return (
+    <div className="space-y-4">
+      {/* Filtro */}
+      <Input
+        placeholder="Filtrar por data ou status..."
+        value={filtro}
+        onChange={(e) => setFiltro(e.target.value)}
+      />
+
+      {/* Status */}
+      {isLoadingServicos && <p className="text-slate-600">Carregando serviços...</p>}
+      {isErrorServicos && <p className="text-red-600">Erro ao carregar serviços</p>}
+
+      {/* Tabela */}
+      {!isLoadingServicos && !isErrorServicos && (
+        <div className="overflow-x-auto rounded-lg border border-slate-200">
+          <table className="w-full text-sm">
+            <thead className="bg-slate-50 border-b border-slate-200">
+              <tr>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Data
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Status
+                </th>
+                <th className="px-6 py-3 text-left font-semibold text-slate-900">
+                  Ações
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-200">
+              {servicosFiltrados.map((servico) => (
+                <tr key={servico.id} className="hover:bg-slate-50 transition-colors">
+                  <td className="px-6 py-4 text-slate-900">
+                    {new Date(servico.data).toLocaleDateString('pt-BR', {
+                      weekday: 'long',
+                      year: 'numeric',
+                      month: 'long',
+                      day: 'numeric',
+                    })}
+                  </td>
+                  <td className="px-6 py-4">
+                    <span
+                      className={`inline-flex items-center rounded-full px-3 py-1 text-xs font-semibold ${
+                        servico.status === 'EM_ANDAMENTO'
+                          ? 'bg-blue-100 text-blue-800'
+                          : 'bg-slate-100 text-slate-800'
+                      }`}
+                    >
+                      {servico.status === 'EM_ANDAMENTO' ? 'Em Andamento' : 'Fechado'}
+                    </span>
+                  </td>
+                  <td className="px-6 py-4">
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => setServicoSelecionado(servico)}
+                    >
+                      Editar
+                    </Button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {servicosFiltrados.length === 0 && (
+            <div className="px-6 py-8 text-center text-slate-600">
+              {servicos.length === 0 ? 'Nenhum serviço encontrado' : 'Nenhum serviço corresponde ao filtro'}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Modal de Edição */}
+      <ModalServico
+        key={servicoSelecionado?.id ?? 'novo-servico'}
+        isOpen={!!servicoSelecionado}
+        onClose={() => setServicoSelecionado(null)}
+        servico={servicoSelecionado}
+      />
+    </div>
+  )
+}

--- a/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
+++ b/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
@@ -4,13 +4,21 @@ import { Input } from "../../ui/Input"
 import { useModalServico } from "../../../hooks/useModalServico"
 import type { Aluno } from "../../../types/aluno.types"
 
+interface Servico {
+  id: string
+  data: string
+  status?: 'EM_ANDAMENTO' | 'FECHADO'
+  membros?: { alunoNumero: number; funcao: string }[]
+}
 
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
+  servico?: Servico | null
 }
 
-export const ModalServico = ({ isOpen, onClose }: ModalProps) => {
+export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
+  const isEdicao = Boolean(servico)
   const { 
     dataServico, setDataServico, membros, alunos, 
     adicionarMembro, removerMembro, atualizarMembro,
@@ -24,12 +32,17 @@ export const ModalServico = ({ isOpen, onClose }: ModalProps) => {
         <Button onClick={onClose} className="absolute top-4 right-4 text-slate-400 hover:text-slate-600">
           <X size={24} />
         </Button>
+
+        <h2 className="text-2xl font-bold text-slate-900 mb-4">
+          {isEdicao ? "Visualizar Serviço" : "Criar Serviço"}
+        </h2>
       
         <Input 
         label="Data"
-        type="data"
+        type="date"
         value={dataServico}
         onChange={(e) => setDataServico(e.target.value)}
+        disabled={isEdicao}
         className="mt-4 mb-4"
         />
 
@@ -43,7 +56,8 @@ export const ModalServico = ({ isOpen, onClose }: ModalProps) => {
               <select 
                 value={membro.alunoNumero}
                 onChange={(e) => atualizarMembro(index, 'alunoNumero', e.target.value)}
-                className="flex-1 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                disabled={isEdicao}
+                className="flex-1 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
               >
                 <option value="">Selecionar Aluno...</option>
                 {alunos.map((aluno: Aluno) => (
@@ -57,7 +71,8 @@ export const ModalServico = ({ isOpen, onClose }: ModalProps) => {
               <select 
                 value={membro.funcao}
                 onChange={(e) => atualizarMembro(index, 'funcao', e.target.value)}
-                className="w-1/3 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                disabled={isEdicao}
+                className="w-1/3 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
               >
                 <option value="">Função...</option>
                 <option value="SGT_DIA">Sgt Dia</option>
@@ -69,25 +84,28 @@ export const ModalServico = ({ isOpen, onClose }: ModalProps) => {
               {/* Botão Remover Linha */}
               <button 
                 onClick={() => removerMembro(index)}
-                className="p-2 text-red-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                disabled={isEdicao}
+                className="p-2 text-red-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Trash2 size={18} />
               </button>
             </div>
           ))}
 
-          <Button 
-          leftIcon={<Plus />}
-          onClick={adicionarMembro}>Adicionar Aluno</Button>
+          {!isEdicao && (
+            <Button 
+            leftIcon={<Plus />}
+            onClick={adicionarMembro}>Adicionar Aluno</Button>
+          )}
 
         </div>
         
         <Button 
         className="mt-6"
         onClick={handleSalvar}
-        disabled={isSalvando}
+        disabled={isSalvando || isEdicao}
         >
-          Criar Serviço
+          {isEdicao ? "Fechar" : "Criar Serviço"}
         </Button>
 
 

--- a/frontend-app/src/hooks/useAlteracoesPage.ts
+++ b/frontend-app/src/hooks/useAlteracoesPage.ts
@@ -7,20 +7,24 @@ import {
   type Setor,
 } from "../constants/locais"
 import { fetchAlteracoes } from "../services/alteracao.service"
+import type { Alteracao } from "../types/alterecao.types"
 
 export const useAlteracoesPage = () => {
   const [setorAtivo, setSetorAtivo] = useState<Setor>(ORDEM_SETORES[0])
 
-  const { data: alteracoes, isLoading, isError } = useQuery({
+  const { data: alteracoes = [], isLoading, isError } = useQuery<Alteracao[]>({
     queryKey: ["alteracoesAtuais"],
-    queryFn: fetchAlteracoes,
+    queryFn: async () => {
+      const result = await fetchAlteracoes()
+      return result ?? []
+    },
   })
 
-  const listaAlteracoes = alteracoes ?? []
+  const listaAlteracoes = alteracoes as Alteracao[]
   const abaAtiva = LABEL_SETOR[setorAtivo]
   const comodosSetorAtivo = MAPEAMENTO_QUARTOS[setorAtivo]
   const alteracoesSetorAtivo = listaAlteracoes.filter(
-    (alteracao) => alteracao.local === setorAtivo,
+    (alteracao: Alteracao) => alteracao.local === setorAtivo,
   )
 
 

--- a/frontend-app/src/hooks/useConfiguracoes.ts
+++ b/frontend-app/src/hooks/useConfiguracoes.ts
@@ -1,0 +1,62 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { fetchAlteracoes, atualizarAlteracao } from '../services/alteracao.service'
+import { fetchServicos, atualizarServico } from '../services/sevicos.service'
+import type { Alteracao, AtualizarAlteracaoInput } from '../types/alterecao.types'
+
+export const useConfiguracoes = () => {
+  const queryClient = useQueryClient()
+
+  // Alterações
+  const {
+    data: alteracoes = [],
+    isLoading: isLoadingAlteracoes,
+    isError: isErrorAlteracoes,
+  } = useQuery({
+    queryKey: ['alteracoesConfiguracao'],
+    queryFn: () => fetchAlteracoes(),
+  })
+
+  const atualizarAlteracaoMutacao = useMutation({
+    mutationFn: async (dados: { id: string; payload: AtualizarAlteracaoInput }) => {
+      return await atualizarAlteracao(dados.id, dados.payload)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['alteracoesConfiguracao'] })
+    },
+  })
+
+  // Serviços
+  const {
+    data: servicos = [],
+    isLoading: isLoadingServicos,
+    isError: isErrorServicos,
+  } = useQuery({
+    queryKey: ['servicosConfiguracao'],
+    queryFn: () => fetchServicos(),
+  })
+
+  const atualizarServicoMutacao = useMutation({
+    mutationFn: async (dados: { id: string; status: 'EM_ANDAMENTO' | 'FECHADO' }) => {
+      return await atualizarServico(dados.id, dados.status)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['servicosConfiguracao'] })
+    },
+  })
+
+  return {
+    // Alterações
+    alteracoes: alteracoes as Alteracao[],
+    isLoadingAlteracoes,
+    isErrorAlteracoes,
+    atualizarAlteracao: atualizarAlteracaoMutacao.mutate,
+    isUpdatingAlteracao: atualizarAlteracaoMutacao.isPending,
+
+    // Serviços
+    servicos,
+    isLoadingServicos,
+    isErrorServicos,
+    atualizarServico: atualizarServicoMutacao.mutate,
+    isUpdatingServico: atualizarServicoMutacao.isPending,
+  }
+}

--- a/frontend-app/src/hooks/useModalAlteracao.ts
+++ b/frontend-app/src/hooks/useModalAlteracao.ts
@@ -1,18 +1,36 @@
 import { useEffect, useMemo, useRef, useState } from "react"
 import { useQueryClient } from "@tanstack/react-query"
-import { criarAlteracao, uploadFotoAlteracao } from "../services/alteracao.service"
-import type { Setor } from "../constants/locais"
+import {
+  atualizarAlteracao,
+  criarAlteracao,
+  uploadFotoAlteracao,
+} from "../services/alteracao.service"
+import { MAPEAMENTO_QUARTOS, type Setor } from "../constants/locais"
+import type { Alteracao, StatusAlteracao } from "../types/alterecao.types"
 
 interface UseModalAlteracaoParams {
   onClose: () => void
   local: Setor
   comodo: string
-  onCreated?: () => void
+  alteracao?: Alteracao | null
+  onSaved?: () => void
 }
 
-export const useModalAlteracao = ({ onClose, local, comodo, onCreated }: UseModalAlteracaoParams) => {
+export const useModalAlteracao = ({
+  onClose,
+  local,
+  comodo,
+  alteracao,
+  onSaved,
+}: UseModalAlteracaoParams) => {
   const queryClient = useQueryClient()
-  const [descricao, setDescricao] = useState("")
+  const isEdicao = Boolean(alteracao)
+  const [descricao, setDescricao] = useState(alteracao?.descricao ?? "")
+  const [localSelecionado, setLocalSelecionado] = useState<Setor>(alteracao?.local ?? local)
+  const [comodoSelecionado, setComodoSelecionado] = useState<string>(alteracao?.comodo ?? comodo)
+  const [statusSelecionado, setStatusSelecionado] = useState<StatusAlteracao>(
+    alteracao?.status ?? "NOVA",
+  )
   const [arquivo, setArquivo] = useState<File | null>(null)
   const [erro, setErro] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -30,8 +48,25 @@ export const useModalAlteracao = ({ onClose, local, comodo, onCreated }: UseModa
     }
   }, [previewUrl])
 
+  // Atualiza o cômodo imediatamente quando o local é alterado,
+  // evitando setState dentro de um useEffect que pode causar renders encadeados.
+  const handleMudarLocal = (novoLocal: Setor) => {
+    setLocalSelecionado(novoLocal)
+
+    const novosComodos = MAPEAMENTO_QUARTOS[novoLocal] ?? []
+
+    if (novosComodos.length > 0) {
+      setComodoSelecionado(novosComodos[0].id)
+    } else {
+      setComodoSelecionado("")
+    }
+  }
+
   const resetForm = () => {
-    setDescricao("")
+    setDescricao(alteracao?.descricao ?? "")
+    setLocalSelecionado(alteracao?.local ?? local)
+    setComodoSelecionado(alteracao?.comodo ?? comodo)
+    setStatusSelecionado(alteracao?.status ?? "NOVA")
     setArquivo(null)
     setErro(null)
     setIsSubmitting(false)
@@ -66,10 +101,31 @@ export const useModalAlteracao = ({ onClose, local, comodo, onCreated }: UseModa
       fotoUrl = upload.fotoUrl
     }
 
+    if (isEdicao && alteracao) {
+      const alteracaoAtualizada = await atualizarAlteracao(alteracao.id, {
+        descricao: descricaoLimpa,
+        local: localSelecionado,
+        comodo: comodoSelecionado,
+        fotoUrl: fotoUrl ?? alteracao.fotoUrl,
+        status: statusSelecionado,
+      })
+
+      if (!alteracaoAtualizada) {
+        setErro("Não foi possível atualizar a alteração.")
+        setIsSubmitting(false)
+        return
+      }
+
+      await queryClient.invalidateQueries({ queryKey: ["alteracoesAtuais"] })
+      onSaved?.()
+      handleClose()
+      return
+    }
+
     const alteracaoCriada = await criarAlteracao({
       descricao: descricaoLimpa,
-      local,
-      comodo,
+      local: localSelecionado,
+      comodo: comodoSelecionado,
       fotoUrl,
     })
 
@@ -80,13 +136,21 @@ export const useModalAlteracao = ({ onClose, local, comodo, onCreated }: UseModa
     }
 
     await queryClient.invalidateQueries({ queryKey: ["alteracoesAtuais"] })
-    onCreated?.()
+    onSaved?.()
     handleClose()
   }
 
   return {
     descricao,
     setDescricao,
+    localSelecionado,
+    setLocalSelecionado: handleMudarLocal,
+    setLocalSelecionadoRaw: setLocalSelecionado,
+    comodoSelecionado,
+    setComodoSelecionado,
+    statusSelecionado,
+    setStatusSelecionado,
+    isEdicao,
     arquivo,
     setArquivo,
     erro,
@@ -95,5 +159,6 @@ export const useModalAlteracao = ({ onClose, local, comodo, onCreated }: UseModa
     handleSubmit,
     handleClose,
     previewUrl,
+    fotoAtualUrl: alteracao?.fotoUrl ?? null,
   }
 }

--- a/frontend-app/src/hooks/useToggleQuarto.ts
+++ b/frontend-app/src/hooks/useToggleQuarto.ts
@@ -1,11 +1,16 @@
 import { useState } from "react"
+import { atualizarStatusAlteracao } from "../services/alteracao.service"
+import { useQueryClient } from "@tanstack/react-query"
+import type { Alteracao } from "../types/alterecao.types"
 
 export const useToggleQuarto = (initialExpandedComodoId?: string) => {
+  const queryClient = useQueryClient()
   const [quartosExpandidos, setQuartosExpandidos] = useState<string[]>(
     initialExpandedComodoId ? [initialExpandedComodoId] : [],
   )
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [comodoSelecionado, setComodoSelecionado] = useState<string | null>(null)
+  const [alteracaoSelecionada, setAlteracaoSelecionada] = useState<Alteracao | null>(null)
 
   const toggleQuarto = (id: string) => {
     setQuartosExpandidos((prev) =>
@@ -14,21 +19,40 @@ export const useToggleQuarto = (initialExpandedComodoId?: string) => {
   }
 
   const abrirModalAlteracao = (comodoId: string) => {
+    setAlteracaoSelecionada(null)
     setComodoSelecionado(comodoId)
+    setIsModalOpen(true)
+  }
+
+  const abrirModalEdicaoAlteracao = (alteracao: Alteracao) => {
+    setAlteracaoSelecionada(alteracao)
+    setComodoSelecionado(alteracao.comodo)
     setIsModalOpen(true)
   }
 
   const fecharModalAlteracao = () => {
     setIsModalOpen(false)
     setComodoSelecionado(null)
+    setAlteracaoSelecionada(null)
+  }
+
+  const handleResolverAlteracao = async (alteracaoId: string) => {
+    const alteracaoAtualizada = await atualizarStatusAlteracao(alteracaoId)
+
+    if (!alteracaoAtualizada) return
+
+    await queryClient.invalidateQueries({ queryKey: ["alteracoesAtuais"] })
   }
 
   return {
     quartosExpandidos,
     isModalOpen,
     comodoSelecionado,
+    alteracaoSelecionada,
     toggleQuarto,
     abrirModalAlteracao,
+    abrirModalEdicaoAlteracao,
     fecharModalAlteracao,
+    handleResolverAlteracao,
   }
 }

--- a/frontend-app/src/pages/Configuracoes.tsx
+++ b/frontend-app/src/pages/Configuracoes.tsx
@@ -1,0 +1,41 @@
+import { useState } from 'react'
+import { Tabs } from '../components/ui/Tabs'
+import { AlteracoesConfiguracoes } from '../components/pages/Configuracoes/AlteracoesConfiguracoes'
+import { ServicosConfiguracoes } from '../components/pages/Configuracoes/ServicosConfiguracoes'
+
+export const ConfiguracoesPage = () => {
+  const [abaAtiva, setAbaAtiva] = useState('alteracoes')
+
+  const abas = ['Alterações', 'Serviços']
+
+  const handleAbaChange = (novaAba: string) => {
+    if (novaAba === 'Alterações') {
+      setAbaAtiva('alteracoes')
+    } else if (novaAba === 'Serviços') {
+      setAbaAtiva('servicos')
+    }
+  }
+
+  return (
+    <div className="space-y-10">
+      {/* Header */}
+      <div>
+        <h1 className="text-3xl font-bold text-slate-900">Configurações</h1>
+        <p className="text-slate-600">Gerencie alterações e serviços</p>
+      </div>
+
+      {/* NavBar */}
+      <Tabs 
+        options={abas}
+        activeTab={abaAtiva === 'alteracoes' ? 'Alterações' : 'Serviços'}
+        onChange={handleAbaChange}
+      />
+
+      {/* Conteúdo */}
+      <div className="space-y-4">
+        {abaAtiva === 'alteracoes' && <AlteracoesConfiguracoes />}
+        {abaAtiva === 'servicos' && <ServicosConfiguracoes />}
+      </div>
+    </div>
+  )
+}

--- a/frontend-app/src/services/alteracao.service.ts
+++ b/frontend-app/src/services/alteracao.service.ts
@@ -1,9 +1,16 @@
 import { api } from "./api"
-import type { Alteracao, CriarAlteracaoInput } from "../types/alterecao.types"
+import type {
+  AtualizarAlteracaoInput,
+  Alteracao,
+  CriarAlteracaoInput,
+  StatusAlteracao,
+} from "../types/alterecao.types"
 
-export const fetchAlteracoes = async (): Promise<Alteracao[] | null> => {
+export const fetchAlteracoes = async (
+  params?: Partial<{ status: StatusAlteracao; local: string; comodo: string }>,
+): Promise<Alteracao[] | null> => {
   try {
-    const response = await api.get('/alteracoes')
+    const response = await api.get('/alteracoes', { params })
     if(response.data) {
       return response.data
     }
@@ -54,6 +61,42 @@ export const criarAlteracao = async (
     return null
   } catch (error) {
     console.error("Erro ao criar alteração: ", error)
+    return null
+  }
+}
+
+export const atualizarAlteracao = async (
+  alteracaoId: string,
+  payload: AtualizarAlteracaoInput,
+): Promise<Alteracao | null> => {
+  try {
+    const response = await api.patch(`/alteracoes/${alteracaoId}`, payload)
+
+    if (response.data) {
+      return response.data
+    }
+
+    return null
+  } catch (error) {
+    console.error("Erro ao atualizar alteração: ", error)
+    return null
+  }
+}
+
+export async function atualizarStatusAlteracao(
+  alteracaoId: string,
+  status: StatusAlteracao = "RESOLVIDA",
+): Promise<Alteracao | null> {
+  try {
+    const response = await api.patch(`/alteracoes/${alteracaoId}/status`, { status })
+
+    if (response.data) {
+      return response.data
+    }
+
+    return null
+  } catch (error) {
+    console.error("Erro ao atualizar status da alteração: ", error)
     return null
   }
 }

--- a/frontend-app/src/services/sevicos.service.ts
+++ b/frontend-app/src/services/sevicos.service.ts
@@ -33,3 +33,26 @@ export const buscarSgtDeDia = async (): Promise<ServicoAtualSgtDiaDTO | null> =>
     return null;
   }
 };
+
+export const fetchServicos = async () => {
+  try {
+    const response = await api.get('/servicos');
+    return response.data;
+  } catch (error) {
+    console.error("Erro ao buscar serviços:", error);
+    return [];
+  }
+};
+
+export const atualizarServico = async (
+  servicoId: string,
+  status: 'EM_ANDAMENTO' | 'FECHADO'
+) => {
+  try {
+    const response = await api.patch(`/servicos/${servicoId}`, { status });
+    return response.data;
+  } catch (error) {
+    console.error("Erro ao atualizar serviço:", error);
+    throw error;
+  }
+};

--- a/frontend-app/src/types/alterecao.types.ts
+++ b/frontend-app/src/types/alterecao.types.ts
@@ -1,11 +1,14 @@
 import type { Setor } from "../constants/locais"
 
+export type StatusAlteracao = "NOVA" | "PENDENTE" | "RESOLVIDA"
+
 export interface Alteracao {
   id: string,
   descricao: string,
   local: Setor,
   fotoUrl: string | null,
   comodo: string,
+  status: StatusAlteracao,
 }
 
 export interface CriarAlteracaoInput {
@@ -13,4 +16,12 @@ export interface CriarAlteracaoInput {
   local: Setor
   comodo: string
   fotoUrl: string | null
+}
+
+export interface AtualizarAlteracaoInput {
+  descricao: string
+  local: Setor
+  comodo: string
+  fotoUrl: string | null
+  status: StatusAlteracao
 }


### PR DESCRIPTION
## 📝 Contexto e Motivação
Este PR introduz a base administrativa do sistema (Página de Configurações na Web), permitindo a gestão completa do status de Serviços e Alterações. Além disso, foi realizada uma refatoração profunda na interface e nos hooks do Frontend Web para reaproveitamento de componentes (Modais e Accordions), e os endpoints do Backend foram expandidos para suportar atualizações (PATCH) e filtros dinâmicos.

Embora não feche issues diretamente agora, esta arquitetura prepara o terreno e facilita o fechamento de pelo menos 2 issues mapeadas.

## 🛠️ O que foi feito

### ⚙️ Backend
- **Alterações:** Adicionado suporte a filtros por `query params` no endpoint de listagem. Criada nova rota `PATCH /alteracoes/:id` com schemas de validação para edição completa.
- **Serviços:** Criada nova rota `PATCH /servicos/:id` para permitir a transição de status (ex: Em Andamento ↔ Fechado).

### 💻 Frontend (Web)
- **Painel de Configurações (Novo):** Criada a página de Configurações com abas dedicadas para gestão de Alterações e Serviços, incluindo tabelas com filtros e modais de edição.
- **Refatoração UI:** 
  - O componente `ToggleQuarto` foi extraído e o detalhamento visual movido para um novo componente `DetalhesAlteracao` (Accordion).
  - O `ModalAddAlteracao` foi refatorado para ser inteligente, suportando agora tanto o fluxo de Criação quanto o de Edição.
- **Camada de Dados:** Atualização dos `services`, tipagens e criação/refatoração de hooks (`useConfiguracoes`, `useToggleQuarto`, `useModalAlteracao`) para gerenciar as chamadas à API e o estado local de forma limpa.


## 🔗 Issues Relacionadas
- Prepara o terreno para as issues: #10 e #4  

## 🧪 Como testar
1. **Backend:** Rode o backend localmente e verifique as rotas do Postman, testando os filtros `?status=` na listagem de alterações.
2. **Web (Configurações):** Acesse a nova página de Configurações pelo menu lateral. Teste a troca de abas, os filtros das tabelas e edite o status de um Serviço ou Alteração via Modal.
3. **Web (Página de Alterações):** Expanda o Accordion de um cômodo. O componente deve renderizar os detalhes corretamente (foto, descrição) e permitir abrir o Modal de Edição a partir do item.
