### PR TITLE
Feat/config excluir alteracao

### DIFF
--- a/backend-app/src/controllers/alteracao.controller.ts
+++ b/backend-app/src/controllers/alteracao.controller.ts
@@ -14,6 +14,7 @@ import {
 	atualizarStatusAlteracao,
 	criarAlteracao,
 	listarAlteracoes,
+	deletarAlteracao,
 } from "../services/alteracao.service.js";
 import { uploadAlteracaoImage } from "../lib/cloudinary.js";
 
@@ -141,6 +142,28 @@ export const uploadFotoAlteracao = async (req: Request, res: Response) => {
 		console.error("Erro ao fazer upload da foto da alteração: ", err);
 		return res.status(500).json({
 			error: "Erro interno do servidor ao fazer upload da foto",
+		});
+	}
+};
+
+export const removerAlteracao = async (req: Request, res: Response) => {
+	try {
+		const paramsValidados = alteracaoIdParamSchema.parse(req.params);
+		await deletarAlteracao(paramsValidados.id);
+		return res.status(204).send();
+	} catch (err: unknown) {
+		const zodResponse = handleZodError(res, err);
+		if (zodResponse) return zodResponse;
+
+		if (err instanceof Error && err.message === "ALTERACAO_NAO_ENCONTRADA") {
+			return res.status(404).json({
+				error: "Alteração não encontrada",
+			});
+		}
+
+		console.error("Erro ao remover alteração: ", err);
+		return res.status(500).json({
+			error: "Erro interno do servidor ao remover alteração",
 		});
 	}
 };

--- a/backend-app/src/routes/alteracoes.routes.ts
+++ b/backend-app/src/routes/alteracoes.routes.ts
@@ -5,6 +5,7 @@ import {
   criarNovaAlteracao,
   listarAlteracoesTodas,
   uploadFotoAlteracao,
+  removerAlteracao,
 } from "../controllers/alteracao.controller.js";
 import { uploadImagem } from "../middlewares/upload.middleware.js";
 
@@ -15,5 +16,6 @@ router.post("/", criarNovaAlteracao);
 router.post("/upload", uploadImagem.single("foto"), uploadFotoAlteracao);
 router.patch("/:id", atualizarDadosDaAlteracao);
 router.patch("/:id/status", atualizarStatusDaAlteracao);
+router.delete("/:id", removerAlteracao);
 
 export default router;

--- a/backend-app/src/services/alteracao.service.ts
+++ b/backend-app/src/services/alteracao.service.ts
@@ -93,3 +93,18 @@ export const atualizarAlteracao = async (
     data: dadosParaAtualizacao,
   })
 }
+
+export const deletarAlteracao = async (id: string): Promise<void> => {
+  const alteracaoExistente = await prisma.alteracao.findUnique({
+    where: { id },
+    select: { id: true },
+  })
+
+  if (!alteracaoExistente) {
+    throw new Error("ALTERACAO_NAO_ENCONTRADA")
+  }
+
+  await prisma.alteracao.delete({
+    where: { id },
+  })
+}

--- a/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
@@ -4,16 +4,24 @@ import { Button } from '../../ui/Button'
 import { Input } from '../../ui/Input'
 import { ModalAddAlteracao } from '../Alteracoes/ModalAddAlteracao'
 import type { Alteracao } from '../../../types/alterecao.types'
+import { Trash2 } from 'lucide-react'
 
 export const AlteracoesConfiguracoes = () => {
   const {
     alteracoes,
     isLoadingAlteracoes,
     isErrorAlteracoes,
+    removerAlteracao,
   } = useConfiguracoes()
 
   const [alteracaoSelecionada, setAlteracaoSelecionada] = useState<Alteracao | null>(null)
   const [filtro, setFiltro] = useState('')
+
+  const handleExcluir = (id: string) => {
+    if (window.confirm('Tem certeza que deseja excluir esta alteração? Esta ação não pode ser desfeita.')) {
+      removerAlteracao(id)
+    }
+  }
 
   const alteracoesFiltradas = alteracoes.filter((alt) =>
     alt.descricao.toLowerCase().includes(filtro.toLowerCase()) ||
@@ -79,13 +87,23 @@ export const AlteracoesConfiguracoes = () => {
                     </span>
                   </td>
                   <td className="px-6 py-4">
-                    <Button
-                      variant="secondary"
-                      size="sm"
-                      onClick={() => setAlteracaoSelecionada(alteracao)}
-                    >
-                      Editar
-                    </Button>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => setAlteracaoSelecionada(alteracao)}
+                      >
+                        Editar
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="text-red-600 hover:text-red-700 hover:bg-red-50"
+                        onClick={() => handleExcluir(alteracao.id)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </td>
                 </tr>
               ))}

--- a/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/AlteracoesConfiguracoes.tsx
@@ -5,6 +5,7 @@ import { Input } from '../../ui/Input'
 import { ModalAddAlteracao } from '../Alteracoes/ModalAddAlteracao'
 import type { Alteracao } from '../../../types/alterecao.types'
 import { Trash2 } from 'lucide-react'
+import { ModalConfirmacaoExclusao } from './ModalConfirmacaoExclusao'
 
 export const AlteracoesConfiguracoes = () => {
   const {
@@ -12,14 +13,18 @@ export const AlteracoesConfiguracoes = () => {
     isLoadingAlteracoes,
     isErrorAlteracoes,
     removerAlteracao,
+    isRemovingAlteracao,
   } = useConfiguracoes()
 
   const [alteracaoSelecionada, setAlteracaoSelecionada] = useState<Alteracao | null>(null)
+  const [alteracaoParaExcluir, setAlteracaoParaExcluir] = useState<string | null>(null)
   const [filtro, setFiltro] = useState('')
 
-  const handleExcluir = (id: string) => {
-    if (window.confirm('Tem certeza que deseja excluir esta alteração? Esta ação não pode ser desfeita.')) {
-      removerAlteracao(id)
+  const handleConfirmarExclusao = () => {
+    if (alteracaoParaExcluir) {
+      removerAlteracao(alteracaoParaExcluir, {
+        onSuccess: () => setAlteracaoParaExcluir(null)
+      })
     }
   }
 
@@ -99,7 +104,7 @@ export const AlteracoesConfiguracoes = () => {
                         variant="ghost"
                         size="sm"
                         className="text-red-600 hover:text-red-700 hover:bg-red-50"
-                        onClick={() => handleExcluir(alteracao.id)}
+                        onClick={() => setAlteracaoParaExcluir(alteracao.id)}
                       >
                         <Trash2 className="h-4 w-4" />
                       </Button>
@@ -129,6 +134,14 @@ export const AlteracoesConfiguracoes = () => {
           onSaved={() => setAlteracaoSelecionada(null)}
         />
       )}
+
+      {/* Modal de Confirmação de Exclusão */}
+      <ModalConfirmacaoExclusao 
+        isOpen={!!alteracaoParaExcluir}
+        onClose={() => setAlteracaoParaExcluir(null)}
+        onConfirm={handleConfirmarExclusao}
+        isExcluindo={isRemovingAlteracao}
+      />
     </div>
   )
 }

--- a/frontend-app/src/components/pages/Configuracoes/ModalConfirmacaoExclusao.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/ModalConfirmacaoExclusao.tsx
@@ -1,0 +1,67 @@
+import { X, AlertTriangle } from "lucide-react"
+import { Button } from "../../ui/Button"
+
+interface ModalConfirmacaoExclusaoProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  titulo?: string
+  mensagem?: string
+  isExcluindo?: boolean
+}
+
+export const ModalConfirmacaoExclusao = ({
+  isOpen,
+  onClose,
+  onConfirm,
+  titulo = "Confirmar Exclusão",
+  mensagem = "Tem certeza que deseja excluir esta alteração? Esta ação não pode ser desfeita.",
+  isExcluindo = false,
+}: ModalConfirmacaoExclusaoProps) => {
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center bg-black/40 backdrop-blur justify-center p-4">
+      <div className="w-full max-w-md bg-white rounded-xl shadow-2xl p-6 relative">
+        <Button 
+          variant="ghost" 
+          onClick={onClose} 
+          className="absolute top-4 right-4 text-slate-400 hover:text-slate-600 p-1 h-8 w-8"
+        >
+          <X size={20} />
+        </Button>
+
+        <div className="flex items-center gap-3 mb-4 text-red-600">
+          <div className="p-2 bg-red-50 rounded-full">
+            <AlertTriangle size={24} />
+          </div>
+          <h2 className="text-xl font-bold text-slate-900">{titulo}</h2>
+        </div>
+
+        <p className="text-slate-600 mb-8">
+          {mensagem}
+        </p>
+
+        <div className="flex gap-3 justify-end">
+          <Button 
+            variant="secondary" 
+            size="sm"
+            onClick={onClose}
+            disabled={isExcluindo}
+          >
+            Cancelar
+          </Button>
+          <Button 
+            variant="danger"
+            size="sm"
+            onClick={onConfirm}
+            isLoading={isExcluindo}
+            disabled={isExcluindo}
+          >
+            Excluir
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend-app/src/hooks/useConfiguracoes.ts
+++ b/frontend-app/src/hooks/useConfiguracoes.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { fetchAlteracoes, atualizarAlteracao } from '../services/alteracao.service'
+import { fetchAlteracoes, atualizarAlteracao, removerAlteracao } from '../services/alteracao.service'
 import { fetchServicos, atualizarServico } from '../services/sevicos.service'
 import type { Alteracao, AtualizarAlteracaoInput } from '../types/alterecao.types'
 
@@ -19,6 +19,15 @@ export const useConfiguracoes = () => {
   const atualizarAlteracaoMutacao = useMutation({
     mutationFn: async (dados: { id: string; payload: AtualizarAlteracaoInput }) => {
       return await atualizarAlteracao(dados.id, dados.payload)
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['alteracoesConfiguracao'] })
+    },
+  })
+
+  const removerAlteracaoMutacao = useMutation({
+    mutationFn: async (id: string) => {
+      return await removerAlteracao(id)
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['alteracoesConfiguracao'] })
@@ -51,6 +60,8 @@ export const useConfiguracoes = () => {
     isErrorAlteracoes,
     atualizarAlteracao: atualizarAlteracaoMutacao.mutate,
     isUpdatingAlteracao: atualizarAlteracaoMutacao.isPending,
+    removerAlteracao: removerAlteracaoMutacao.mutate,
+    isRemovingAlteracao: removerAlteracaoMutacao.isPending,
 
     // Serviços
     servicos,

--- a/frontend-app/src/services/alteracao.service.ts
+++ b/frontend-app/src/services/alteracao.service.ts
@@ -100,3 +100,13 @@ export async function atualizarStatusAlteracao(
     return null
   }
 }
+
+export const removerAlteracao = async (alteracaoId: string): Promise<boolean> => {
+  try {
+    await api.delete(`/alteracoes/${alteracaoId}`)
+    return true
+  } catch (error) {
+    console.error("Erro ao remover alteração: ", error)
+    return false
+  }
+}


### PR DESCRIPTION
## 🚀 Resumo
Este PR introduz a funcionalidade *full-stack* de exclusão de alterações na página de Configurações. Foi implementado o endpoint de deleção no backend e, no frontend, um fluxo seguro e responsivo utilizando um modal customizado de confirmação, substituindo o `window.confirm` nativo e garantindo a atualização instantânea da interface via React Query.

## 🛠️ O que foi feito

### ⚙️ Backend
- **Rota e Controller:** Criação do endpoint `DELETE /api/alteracoes/:id` e do método `removerAlteracao` retornando o status `204 (No Content)`.
- **Regra de Negócio:** Atualização do `alteracao.service.ts` para buscar e validar a existência do registro no banco de dados antes de efetuar a exclusão.

### 💻 Frontend
- **Novo Componente de UI:** Criação do `ModalConfirmacaoExclusao`, padronizado com *backdrop-blur*, ícones da biblioteca Lucide (`AlertTriangle`) e suporte a estados de *loading* (spinner).
- **Integração Visual:** Adição do botão de ação (ícone `Trash2`) na tabela de alterações. Remoção do `window.confirm` e gerenciamento de estado local para controlar a abertura/fechamento do novo modal.
- **Gerenciamento de Estado/Cache:** Atualização do hook `useConfiguracoes.ts` integrando a mutação do exclui. Após o sucesso (`onSuccess`), o cache do React Query é invalidado, removendo a alteração da lista imediatamente sem necessidade de recarregar a página.

## 🔗 Issues Relacionadas
- Closes #34

