### PR TITLE
Fix/config servicos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ backend-app/ativas_29.sql
 backend-app/1_ano.sql
 
 backend-app/alteracoes.sql
+backup_sgt_dia.sql

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ backend-app/1_ano.sql
 
 backend-app/alteracoes.sql
 backup_sgt_dia.sql
+backend-app/ativas29.sql

--- a/backend-app/src/controllers/servicos.controller.ts
+++ b/backend-app/src/controllers/servicos.controller.ts
@@ -68,7 +68,7 @@ export const atualizarServico = async (req: Request, res: Response) => {
     const { id } = servicoIdParamSchema.parse(req.params);
     const dadosValidados = atualizarServicoSchema.parse(req.body);
 
-    const servicoAtualizado = await atualizarServicoService(id, dadosValidados.status);
+    const servicoAtualizado = await atualizarServicoService(id, dadosValidados);
 
     return res.status(200).json(servicoAtualizado);
   } catch (err: unknown) {

--- a/backend-app/src/schemas/servicos.schema.ts
+++ b/backend-app/src/schemas/servicos.schema.ts
@@ -38,7 +38,9 @@ export const servicoIdParamSchema = z.object({
 });
 
 export const atualizarServicoSchema = z.object({
-  status: z.enum(StatusServico),
+  status: z.enum(StatusServico).optional(),
+  data: dataServicoSchema.optional(),
+  membros: membrosServicoSchema.optional(),
 });
 
 export type AtualizarServicoInput = z.infer<typeof atualizarServicoSchema>

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -39,6 +39,9 @@ export const criarNovoServico = async (input: CriarServicoBody ) => {
 
 export const listarServicosService = async () => {
   const servicos = await prisma.servico.findMany({
+    include: {
+      membrosGuarnicao: true
+    },
     orderBy: {
       data: 'desc'
     }
@@ -86,12 +89,43 @@ export const listarServicoAtualService = async () => {
 
 export const atualizarServicoService = async (
   servicoId: string,
-  status: 'EM_ANDAMENTO' | 'FECHADO'
+  dados: AtualizarServicoInput
 ) => {
-  const servicoAtualizado = await prisma.servico.update({
-    where: { id: servicoId },
-    data: { status },
-  })
+  const { status, data, membros } = dados
 
-  return servicoAtualizado
+  return await prisma.$transaction(async (tx) => {
+    if (membros) {
+      // Remover membros antigos
+      await tx.membroGuarnicao.deleteMany({
+        where: { servicoId }
+      })
+
+      // Adicionar novos membros
+      await tx.servico.update({
+        where: { id: servicoId },
+        data: {
+          membrosGuarnicao: {
+            create: membros.map((m) => ({
+              alunoNumero: m.alunoNumero,
+              funcao: m.funcao,
+            })),
+          },
+        },
+      })
+    }
+
+    // Atualizar outros campos
+    const servicoAtualizado = await tx.servico.update({
+      where: { id: servicoId },
+      data: {
+        ...(status ? { status } : {}),
+        ...(data ? { data } : {}),
+      },
+      include: {
+        membrosGuarnicao: true
+      }
+    })
+
+    return servicoAtualizado
+  })
 }

--- a/backend-app/src/services/servicos.service.ts
+++ b/backend-app/src/services/servicos.service.ts
@@ -1,6 +1,6 @@
 import { prisma } from "../lib/prisma.js";
 import { FuncaoMembroGuarnicao } from "@prisma/client";
-import type { CriarServicoBody, ServicoAtualSgtDiaDTO } from "../schemas/servicos.schema.js";
+import type { CriarServicoBody, ServicoAtualSgtDiaDTO, AtualizarServicoInput } from "../schemas/servicos.schema.js";
 
 export const criarNovoServico = async (input: CriarServicoBody ) => {
   const servicoCriado = await prisma.$transaction(async (tx) => {
@@ -22,7 +22,7 @@ export const criarNovoServico = async (input: CriarServicoBody ) => {
           data: {
             data: input.data,
             membrosGuarnicao: {
-              create: input.membros.map((m) => ({
+              create: input.membros.map((m: { alunoNumero: number; funcao: FuncaoMembroGuarnicao }) => ({
                 alunoNumero: m.alunoNumero,
                 funcao: m.funcao,
               })),
@@ -105,9 +105,9 @@ export const atualizarServicoService = async (
         where: { id: servicoId },
         data: {
           membrosGuarnicao: {
-            create: membros.map((m) => ({
+            create: membros.map((m: { alunoNumero: number; funcao: string }) => ({
               alunoNumero: m.alunoNumero,
-              funcao: m.funcao,
+              funcao: m.funcao as FuncaoMembroGuarnicao,
             })),
           },
         },

--- a/frontend-app/src/components/pages/Configuracoes/ServicosConfiguracoes.tsx
+++ b/frontend-app/src/components/pages/Configuracoes/ServicosConfiguracoes.tsx
@@ -8,7 +8,7 @@ interface Servico {
   id: string
   data: string
   status: 'EM_ANDAMENTO' | 'FECHADO'
-  membros?: { alunoNumero: number; funcao: string }[]
+  membrosGuarnicao?: { alunoNumero: number; funcao: string }[]
 }
 
 export const ServicosConfiguracoes = () => {

--- a/frontend-app/src/components/pages/Dashboard/AlunoAutocomplete.tsx
+++ b/frontend-app/src/components/pages/Dashboard/AlunoAutocomplete.tsx
@@ -1,0 +1,97 @@
+import { useState, useEffect, useRef } from "react"
+import { Search } from "lucide-react"
+import { Input } from "../../ui/Input"
+import type { Aluno } from "../../../types/aluno.types"
+
+interface AlunoAutocompleteProps {
+  value: number
+  onChange: (v: string) => void
+  alunos: Aluno[]
+  disabled?: boolean
+}
+
+export const AlunoAutocomplete = ({ 
+  value, 
+  onChange, 
+  alunos, 
+  disabled 
+}: AlunoAutocompleteProps) => {
+  const [searchTerm, setSearchTerm] = useState("")
+  const [isOpen, setIsOpen] = useState(false)
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Sincronizar termo de busca com o valor selecionado
+  useEffect(() => {
+    const selected = alunos.find(a => a.numero === value)
+    if (selected) {
+      setSearchTerm(`${selected.nomeGuerra} (${selected.numero})`)
+    } else if (value === 0) {
+      setSearchTerm("")
+    }
+  }, [value, alunos])
+
+  // Fechar ao clicar fora
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+        // Resetar para o nome selecionado se fechar sem escolher
+        const selected = alunos.find(a => a.numero === value)
+        if (selected) {
+          setSearchTerm(`${selected.nomeGuerra} (${selected.numero})`)
+        } else {
+          setSearchTerm("")
+        }
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside)
+    return () => document.removeEventListener("mousedown", handleClickOutside)
+  }, [value, alunos])
+
+  const filtered = alunos.filter(a => 
+    a.nomeGuerra.toLowerCase().includes(searchTerm.toLowerCase()) || 
+    a.numero.toString().includes(searchTerm)
+  )
+
+  return (
+    <div ref={containerRef} className="relative flex-1">
+      <Input
+        value={searchTerm}
+        onChange={(e) => {
+          setSearchTerm(e.target.value)
+          setIsOpen(true)
+          if (e.target.value === "") onChange("0")
+        }}
+        onFocus={() => setIsOpen(true)}
+        placeholder="Buscar Aluno..."
+        disabled={disabled}
+        iconRight={<Search size={18} />}
+        className="!h-10 !py-2"
+      />
+
+      {isOpen && !disabled && (
+        <div className="absolute z-[60] w-full mt-1 bg-white border border-slate-200 rounded-lg shadow-xl max-h-60 overflow-auto">
+          {filtered.length > 0 ? (
+            filtered.map(aluno => (
+              <button
+                key={aluno.numero}
+                type="button"
+                className="w-full text-left p-3 hover:bg-blue-50 transition-colors border-b border-slate-50 last:border-0 flex justify-between items-center"
+                onClick={() => {
+                  onChange(aluno.numero.toString())
+                  setSearchTerm(`${aluno.nomeGuerra} (${aluno.numero})`)
+                  setIsOpen(false)
+                }}
+              >
+                <span className="font-semibold text-slate-900">{aluno.nomeGuerra}</span>
+                <span className="text-slate-500 text-xs">{aluno.numero}</span>
+              </button>
+            ))
+          ) : (
+            <div className="p-3 text-slate-500 text-center text-sm italic">Nenhum aluno encontrado</div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
+++ b/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
@@ -8,7 +8,7 @@ interface Servico {
   id: string
   data: string
   status?: 'EM_ANDAMENTO' | 'FECHADO'
-  membros?: { alunoNumero: number; funcao: string }[]
+  membrosGuarnicao?: { alunoNumero: number; funcao: string }[]
 }
 
 interface ModalProps {
@@ -23,7 +23,7 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
     dataServico, setDataServico, membros, alunos, 
     adicionarMembro, removerMembro, atualizarMembro,
     handleSalvar, isSalvando 
-  } = useModalServico(onClose);
+  } = useModalServico(onClose, servico);
   if(!isOpen) return null 
   return (
     <div className=" fixed inset-0 z-50 flex items-center bg-black/40 backdrop-blur justify-center">
@@ -34,7 +34,7 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
         </Button>
 
         <h2 className="text-2xl font-bold text-slate-900 mb-4">
-          {isEdicao ? "Visualizar Serviço" : "Criar Serviço"}
+          {isEdicao ? "Editar Serviço" : "Criar Serviço"}
         </h2>
       
         <Input 
@@ -42,7 +42,6 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
         type="date"
         value={dataServico}
         onChange={(e) => setDataServico(e.target.value)}
-        disabled={isEdicao}
         className="mt-4 mb-4"
         />
 
@@ -56,7 +55,6 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
               <select 
                 value={membro.alunoNumero}
                 onChange={(e) => atualizarMembro(index, 'alunoNumero', e.target.value)}
-                disabled={isEdicao}
                 className="flex-1 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
               >
                 <option value="">Selecionar Aluno...</option>
@@ -71,7 +69,6 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
               <select 
                 value={membro.funcao}
                 onChange={(e) => atualizarMembro(index, 'funcao', e.target.value)}
-                disabled={isEdicao}
                 className="w-1/3 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
               >
                 <option value="">Função...</option>
@@ -84,7 +81,6 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
               {/* Botão Remover Linha */}
               <button 
                 onClick={() => removerMembro(index)}
-                disabled={isEdicao}
                 className="p-2 text-red-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Trash2 size={18} />
@@ -92,20 +88,20 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
             </div>
           ))}
 
-          {!isEdicao && (
-            <Button 
-            leftIcon={<Plus />}
-            onClick={adicionarMembro}>Adicionar Aluno</Button>
-          )}
+          <Button 
+          leftIcon={<Plus />}
+          variant="secondary"
+          onClick={adicionarMembro}>Adicionar Aluno</Button>
 
         </div>
         
         <Button 
         className="mt-6"
         onClick={handleSalvar}
-        disabled={isSalvando || isEdicao}
+        isLoading={isSalvando}
+        disabled={isSalvando}
         >
-          {isEdicao ? "Fechar" : "Criar Serviço"}
+          {isEdicao ? "Salvar Alterações" : "Criar Serviço"}
         </Button>
 
 

--- a/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
+++ b/frontend-app/src/components/pages/Dashboard/ModalServico.tsx
@@ -2,7 +2,7 @@ import { Plus, Trash2, X } from "lucide-react"
 import { Button } from "../../ui/Button"
 import { Input } from "../../ui/Input"
 import { useModalServico } from "../../../hooks/useModalServico"
-import type { Aluno } from "../../../types/aluno.types"
+import { AlunoAutocomplete } from "./AlunoAutocomplete"
 
 interface Servico {
   id: string
@@ -24,7 +24,9 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
     adicionarMembro, removerMembro, atualizarMembro,
     handleSalvar, isSalvando 
   } = useModalServico(onClose, servico);
+  
   if(!isOpen) return null 
+  
   return (
     <div className=" fixed inset-0 z-50 flex items-center bg-black/40 backdrop-blur justify-center">
 
@@ -51,25 +53,18 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
           {membros.map((membro, index) => (
             <div key={index} className="flex gap-3 items-center">
               
-              {/* Select do Aluno */}
-              <select 
+              {/* Busca de Aluno Autocomplete */}
+              <AlunoAutocomplete 
                 value={membro.alunoNumero}
-                onChange={(e) => atualizarMembro(index, 'alunoNumero', e.target.value)}
-                className="flex-1 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
-              >
-                <option value="">Selecionar Aluno...</option>
-                {alunos.map((aluno: Aluno) => (
-                  <option key={aluno.numero} value={aluno.numero}>
-                    {aluno.nomeGuerra} ({aluno.numero})
-                  </option>
-                ))}
-              </select>
+                onChange={(val) => atualizarMembro(index, 'alunoNumero', val)}
+                alunos={alunos}
+              />
 
               {/* Select da Função */}
               <select 
                 value={membro.funcao}
                 onChange={(e) => atualizarMembro(index, 'funcao', e.target.value)}
-                className="w-1/3 p-2 border border-slate-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed"
+                className="w-1/3 h-10 px-3 border border-slate-200 rounded-xl text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 disabled:bg-slate-100 disabled:cursor-not-allowed transition-colors"
               >
                 <option value="">Função...</option>
                 <option value="SGT_DIA">Sgt Dia</option>
@@ -88,23 +83,28 @@ export const ModalServico = ({ isOpen, onClose, servico }: ModalProps) => {
             </div>
           ))}
 
-          <Button 
-          leftIcon={<Plus />}
-          variant="secondary"
-          onClick={adicionarMembro}>Adicionar Aluno</Button>
+          <div className="flex justify-start">
+            <Button 
+              type="button"
+              leftIcon={<Plus size={18} />}
+              variant="secondary"
+              size="sm"
+              onClick={adicionarMembro}
+            >
+              Adicionar Aluno
+            </Button>
+          </div>
 
         </div>
         
         <Button 
-        className="mt-6"
-        onClick={handleSalvar}
-        isLoading={isSalvando}
-        disabled={isSalvando}
+          className="mt-6 w-full"
+          onClick={handleSalvar}
+          isLoading={isSalvando}
+          disabled={isSalvando}
         >
           {isEdicao ? "Salvar Alterações" : "Criar Serviço"}
         </Button>
-
-
 
       </div>
 

--- a/frontend-app/src/hooks/useConfiguracoes.ts
+++ b/frontend-app/src/hooks/useConfiguracoes.ts
@@ -46,7 +46,7 @@ export const useConfiguracoes = () => {
 
   const atualizarServicoMutacao = useMutation({
     mutationFn: async (dados: { id: string; status: 'EM_ANDAMENTO' | 'FECHADO' }) => {
-      return await atualizarServico(dados.id, dados.status)
+      return await atualizarServico(dados.id, { status: dados.status })
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['servicosConfiguracao'] })

--- a/frontend-app/src/hooks/useDashboardMetrics.ts
+++ b/frontend-app/src/hooks/useDashboardMetrics.ts
@@ -30,7 +30,7 @@ const tonePorSetor: Record<string, DashboardStat["tone"]> = {
 
 export const useDashboardMetrics = (alteracoes: Alteracao[]) => {
   const activities = useMemo<DashboardActivity[]>(() => {
-    return alteracoes.slice(0, 5).map((alteracao) => ({
+    return alteracoes.slice(0, 3).map((alteracao) => ({
       id: alteracao.id,
       title: tituloAtividadePorStatus[alteracao.status],
       description: `${LABEL_SETOR[alteracao.local]} • ${getLabelComodo(alteracao.comodo)}`,

--- a/frontend-app/src/hooks/useModalServico.ts
+++ b/frontend-app/src/hooks/useModalServico.ts
@@ -1,11 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buscarAlunos } from "../services/alunos.service";
-import { criarNovoServico } from "../services/sevicos.service";
+import { criarNovoServico, atualizarServico } from "../services/sevicos.service";
 import { SARGENTO_DIA_ATUAL_QUERY_KEY } from "./useSargentoDiaAtual";
 import { useServicoFormState } from "./useServicoFormState";
 
-export const useModalServico = (onClose: () => void) => {
+export const useModalServico = (onClose: () => void, initialServico?: any) => {
   const queryClient = useQueryClient()
+  const isEdicao = Boolean(initialServico)
 
   const {
     dataServico,
@@ -14,31 +15,49 @@ export const useModalServico = (onClose: () => void) => {
     adicionarMembro,
     removerMembro,
     atualizarMembro,
-  } = useServicoFormState()
+  } = useServicoFormState(initialServico)
 
   const {data : alunos = [] } = useQuery({
     queryKey: ['alunos_lista'],
     queryFn: buscarAlunos
   })
 
-  const mutation = useMutation({
+  const createMutation = useMutation({
     mutationFn: criarNovoServico,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: SARGENTO_DIA_ATUAL_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: ['servicosConfiguracao'] })
       onClose()
     } 
+  })
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: { id: string, data: any }) => atualizarServico(payload.id, payload.data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SARGENTO_DIA_ATUAL_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: ['servicosConfiguracao'] })
+      onClose()
+    }
   })
 
   const handleSalvar = () => {
     const membrosValidos = membros.filter(m => m.alunoNumero !== 0 && m.funcao !== '');
     const dataCompleta = new Date(dataServico + "T12:00:00.000Z").toISOString()
-    mutation.mutate({data: dataCompleta, membros: membrosValidos})
+    
+    if (isEdicao && initialServico?.id) {
+      updateMutation.mutate({
+        id: initialServico.id,
+        data: { data: dataCompleta, membros: membrosValidos }
+      })
+    } else {
+      createMutation.mutate({ data: dataCompleta, membros: membrosValidos })
+    }
   };
 
   return {
     dataServico, setDataServico,
     membros, alunos,
     adicionarMembro, removerMembro, handleSalvar, atualizarMembro,
-    isSalvando: mutation.isPending
+    isSalvando: createMutation.isPending || updateMutation.isPending
   }
 }

--- a/frontend-app/src/hooks/useServicoFormState.ts
+++ b/frontend-app/src/hooks/useServicoFormState.ts
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import type { MembroServicoForm } from "../types/servicoForm.types"
 
 const MEMBROS_INICIAIS: MembroServicoForm[] = [
@@ -7,9 +7,28 @@ const MEMBROS_INICIAIS: MembroServicoForm[] = [
   { alunoNumero: 0, funcao: "PLANTAO" },
 ]
 
-export const useServicoFormState = () => {
+interface InitialServico {
+  data: string
+  membrosGuarnicao?: MembroServicoForm[]
+}
+
+export const useServicoFormState = (initialServico?: InitialServico | null) => {
   const [dataServico, setDataServico] = useState(new Date().toISOString().split("T")[0])
   const [membros, setMembros] = useState<MembroServicoForm[]>(MEMBROS_INICIAIS)
+
+  useEffect(() => {
+    if (initialServico) {
+      if (initialServico.data) {
+        setDataServico(new Date(initialServico.data).toISOString().split("T")[0])
+      }
+      if (initialServico.membrosGuarnicao && initialServico.membrosGuarnicao.length > 0) {
+        setMembros(initialServico.membrosGuarnicao.map(m => ({
+          alunoNumero: m.alunoNumero,
+          funcao: m.funcao
+        })))
+      }
+    }
+  }, [initialServico])
 
   const adicionarMembro = () => setMembros([...membros, { alunoNumero: 0, funcao: "" }])
 

--- a/frontend-app/src/services/sevicos.service.ts
+++ b/frontend-app/src/services/sevicos.service.ts
@@ -46,10 +46,10 @@ export const fetchServicos = async () => {
 
 export const atualizarServico = async (
   servicoId: string,
-  status: 'EM_ANDAMENTO' | 'FECHADO'
+  data: any
 ) => {
   try {
-    const response = await api.patch(`/servicos/${servicoId}`, { status });
+    const response = await api.patch(`/servicos/${servicoId}`, data);
     return response.data;
   } catch (error) {
     console.error("Erro ao atualizar serviço:", error);


### PR DESCRIPTION
## Resumo
Este PR implementa a edição completa de um serviço existente, garantindo o pré-preenchimento dos dados, e inclui uma refatoração importante na interface para melhorar a manutenção do código.

**O que mudou:**
- **Backend:** A rota e o service foram atualizados para suportar a alteração da data e da guarnição (usando transação segura para recriar os membros). A listagem agora inclui os membros.
- **Frontend (Lógica):** Os hooks de estado foram adaptados para receber e popular os dados iniciais do serviço selecionado, invalidando o cache corretamente após salvar as alterações.
- **Frontend (UI & Refatoração):** O `ModalServico` agora permite editar todos os campos no modo de edição. A lógica de busca de alunos foi extraída para um componente modular e independente (`AlunoAutocomplete`), deixando o código do modal muito mais limpo e organizado.

Closes #35