### PR TITLE
fix(alteracoes): exibir apenas pendências ativas no contador do setor

### DIFF
--- a/frontend-app/src/hooks/useAlteracoesPage.ts
+++ b/frontend-app/src/hooks/useAlteracoesPage.ts
@@ -27,6 +27,9 @@ export const useAlteracoesPage = () => {
     (alteracao: Alteracao) => alteracao.local === setorAtivo,
   )
 
+  const alteracoesPendentesSetorAtivo = alteracoesSetorAtivo.filter(
+    (alteracao: Alteracao) => alteracao.status !== 'RESOLVIDA',
+  )
 
   return {
     setorAtivo,
@@ -35,6 +38,7 @@ export const useAlteracoesPage = () => {
     abaAtiva,
     comodosSetorAtivo,
     alteracoesSetorAtivo,
+    alteracoesPendentesSetorAtivo,
     isLoading,
     isError,
   }

--- a/frontend-app/src/pages/Alteracoes.tsx
+++ b/frontend-app/src/pages/Alteracoes.tsx
@@ -12,7 +12,7 @@ export const AlteracoesPage = () => {
   const {
     setorAtivo, setSetorAtivo,
     listaAlteracoes, abaAtiva, comodosSetorAtivo, alteracoesSetorAtivo,
-    isLoading, isError
+    alteracoesPendentesSetorAtivo, isLoading, isError
   } = useAlteracoesPage()
 
   return (
@@ -34,7 +34,7 @@ export const AlteracoesPage = () => {
 
         {!isLoading && !isError && (
           <>
-            <p>Total de alterações no setor: {alteracoesSetorAtivo.length}</p>
+            <p>Total de alterações no setor: {alteracoesPendentesSetorAtivo.length}</p>
 
             <ToggleQuarto
               comodos={comodosSetorAtivo}


### PR DESCRIPTION
## Resumo
- Contador do setor exibia total absoluto incluindo alterações `RESOLVIDA`
- Adicionada constante `alteracoesPendentesSetorAtivo` no hook com filtro `status !== 'RESOLVIDA'`
- UI atualizada para consumir a nova constante