### PR TITLE
feat(sped): add quick-fill buttons for recebimento, passagem and armamento

### DIFF
--- a/frontend-app/src/components/pages/sped/SpedSections.tsx
+++ b/frontend-app/src/components/pages/sped/SpedSections.tsx
@@ -9,9 +9,10 @@ interface SpedSectionsProps {
   openSection: string | null;
   onToggleSection: (section: string) => void;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  onQuickFill?: (field: keyof SpedFormState) => void;
 }
 
-export const SpedSections = ({ formData, openSection, onToggleSection, onChange }: SpedSectionsProps) => {
+export const SpedSections = ({ formData, openSection, onToggleSection, onChange, onQuickFill }: SpedSectionsProps) => {
   return (
     <div className="mt-2 flex flex-col gap-4">
       {SPED_SECTIONS.map((section) => (
@@ -28,6 +29,7 @@ export const SpedSections = ({ formData, openSection, onToggleSection, onChange 
               label={field.label}
               value={formData[field.id]}
               onChange={onChange}
+              onQuickFill={field.hasQuickFill && onQuickFill ? () => onQuickFill(field.id) : undefined}
             />
           ))}
         </SpedAccordion>

--- a/frontend-app/src/components/pages/sped/SpedTextAreaField.tsx
+++ b/frontend-app/src/components/pages/sped/SpedTextAreaField.tsx
@@ -5,9 +5,10 @@ interface SpedTextAreaFieldProps {
   id: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLTextAreaElement>) => void;
+  onQuickFill?: () => void;
 }
 
-export const SpedTextAreaField = ({ label, id, value, onChange }: SpedTextAreaFieldProps) => {
+export const SpedTextAreaField = ({ label, id, value, onChange, onQuickFill }: SpedTextAreaFieldProps) => {
   return (
     <div className="flex flex-col gap-2">
       <label htmlFor={id} className="text-sm font-medium text-gray-700">
@@ -22,6 +23,15 @@ export const SpedTextAreaField = ({ label, id, value, onChange }: SpedTextAreaFi
         placeholder="S/A"
         className="w-full resize-y rounded-md border border-gray-300 p-3 text-sm outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
       />
+      {onQuickFill && (
+        <button
+          type="button"
+          onClick={onQuickFill}
+          className="self-start rounded border border-blue-300 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100"
+        >
+          Usar texto padrão
+        </button>
+      )}
     </div>
   );
 };

--- a/frontend-app/src/constants/sped.ts
+++ b/frontend-app/src/constants/sped.ts
@@ -1,4 +1,15 @@
-import type { SpedSectionDefinition } from '../types/sped.types';
+import type { SpedFormState, SpedSectionDefinition } from '../types/sped.types';
+
+export const SPED_QUICK_FILL_TEMPLATES: Partial<
+  Record<keyof SpedFormState, (nome: string, data: string) => string>
+> = {
+  recebimento: (nome, data) =>
+    `Às [HORA]h, o ALU ${nome.toUpperCase()} assumiu o serviço de Sargento de Dia, recebendo de [NOME_ANTERIOR], na data de ${data}, sem anormalidades.`,
+  passagem: (nome, data) =>
+    `Às [HORA]h, o ALU ${nome.toUpperCase()} passou o serviço de Sargento de Dia para [NOME_PROXIMO], na data de ${data}, sem anormalidades.`,
+  armamento: () =>
+    `Armamento cautelado conforme registro. Não há variação de material.`,
+};
 
 export const INITIAL_SPED_FORM_STATE = {
   recebimento: '',
@@ -19,15 +30,15 @@ export const SPED_SECTIONS: SpedSectionDefinition[] = [
     id: 'assuncao',
     title: 'Assunção e Passagem',
     fields: [
-      { id: 'recebimento', label: '1. Recebimento do serviço' },
-      { id: 'passagem', label: '13. Passagem de serviço' },
+      { id: 'recebimento', label: '1. Recebimento do serviço', hasQuickFill: true },
+      { id: 'passagem', label: '13. Passagem de serviço', hasQuickFill: true },
     ],
   },
   {
     id: 'armamento',
     title: 'Armamento e Pessoal',
     fields: [
-      { id: 'armamento', label: '3. Armamento' },
+      { id: 'armamento', label: '3. Armamento', hasQuickFill: true },
       { id: 'punidos', label: '4. Punidos 1ª Cia' },
       { id: 'visitaMedica', label: '6. Visita médica fora do horário de expediente' },
       { id: 'alunosDispensa', label: '7. Alunos com dispensa' },

--- a/frontend-app/src/hooks/useSpedPage.ts
+++ b/frontend-app/src/hooks/useSpedPage.ts
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSargentoDiaAtual } from './useSargentoDiaAtual';
 import { atualizarSped, obterSped, obterTextoSped } from '../services/sped.service';
-import { INITIAL_SPED_FORM_STATE } from '../constants/sped';
+import { INITIAL_SPED_FORM_STATE, SPED_QUICK_FILL_TEMPLATES } from '../constants/sped';
 import type { SpedCompany, SpedFormState, SpedMessage } from '../types/sped.types';
 
 const SPED_QUERY_KEY = ['sped'];
@@ -216,6 +216,14 @@ export const useSpedPage = () => {
     setOpenSection((current) => (current === section ? null : section));
   };
 
+  const aplicarTemplate = (field: keyof SpedFormState) => {
+    const templateFn = SPED_QUICK_FILL_TEMPLATES[field];
+    if (!templateFn) return;
+    const nome = sgtDia?.nomeCompleto ?? '';
+    const texto = templateFn(nome, dataServicoFormatada);
+    setFormData((prev) => ({ ...prev, [field]: texto }));
+  };
+
   return {
     companhia,
     companhiaLabel,
@@ -234,5 +242,6 @@ export const useSpedPage = () => {
     generatedTexto,
     handleSave,
     handleGenerate,
+    aplicarTemplate,
   };
 };

--- a/frontend-app/src/pages/Sped.tsx
+++ b/frontend-app/src/pages/Sped.tsx
@@ -23,6 +23,7 @@ export const SpedPage = () => {
     servicoId,
     toggleSection,
     generatedTexto,
+    aplicarTemplate,
   } = useSpedPage();
 
   return (
@@ -65,6 +66,7 @@ export const SpedPage = () => {
           openSection={openSection}
           onToggleSection={toggleSection}
           onChange={handleChange}
+          onQuickFill={aplicarTemplate}
         />
         {generatedTexto && (
           <div className="rounded-md border border-gray-200 bg-white p-6">

--- a/frontend-app/src/types/sped.types.ts
+++ b/frontend-app/src/types/sped.types.ts
@@ -17,6 +17,7 @@ export interface SpedFormState {
 export interface SpedSectionField {
   id: keyof SpedFormState;
   label: string;
+  hasQuickFill?: boolean;
 }
 
 export interface SpedSectionDefinition {


### PR DESCRIPTION
## Resumo
- Adiciona botão 'Usar texto padrão' abaixo dos textareas de Recebimento, Passagem de serviço e Armamento
- Ao clicar, preenche o campo com template pré-definido substituindo automaticamente nome do SGT atual e data do serviço
- Hora e nome do SGT anterior/próximo ficam como placeholders `[HORA]`, `[NOME_ANTERIOR]`, `[NOME_PROXIMO]` para preenchimento manual

## Checklist
- [x] Typecheck passa
- [x] Lint passa
- [x] Sem console.log residuais

## Arquivos alterados
- `frontend-app/src/types/sped.types.ts` — adiciona `hasQuickFill?` em `SpedSectionField`
- `frontend-app/src/constants/sped.ts` — adiciona `SPED_QUICK_FILL_TEMPLATES` e marca campos
- `frontend-app/src/hooks/useSpedPage.ts` — adiciona `aplicarTemplate`
- `frontend-app/src/components/pages/sped/SpedTextAreaField.tsx` — adiciona prop `onQuickFill` + botão
- `frontend-app/src/components/pages/sped/SpedSections.tsx` — passa `onQuickFill` para campos marcados
- `frontend-app/src/pages/Sped.tsx` — conecta `aplicarTemplate` ao componente