### PR TITLE
feat(escala): type posto as SetorLocal enum instead of loose string

### DIFF
--- a/backend-app/prisma/migrations/20260615120000_escala_posto_enum/migration.sql
+++ b/backend-app/prisma/migrations/20260615120000_escala_posto_enum/migration.sql
@@ -1,0 +1,17 @@
+-- AlterTable: change escalas.posto from String to SetorLocal enum
+-- Data migration: convert legacy string values to enum values
+
+ALTER TABLE "escalas" ADD COLUMN "posto_new" "SetorLocal";
+
+UPDATE "escalas" SET "posto_new" =
+  CASE "posto"
+    WHEN 'Ala 5o Piso' THEN 'ALA_5_PISO'::"SetorLocal"
+    WHEN '4o Piso'     THEN 'ALA_4_PISO'::"SetorLocal"
+    WHEN '3o Piso'     THEN 'ALA_3_PISO'::"SetorLocal"
+    WHEN 'SegFem'      THEN 'SEG_FEM'::"SetorLocal"
+    ELSE                    'ALA_5_PISO'::"SetorLocal"
+  END;
+
+ALTER TABLE "escalas" ALTER COLUMN "posto_new" SET NOT NULL;
+ALTER TABLE "escalas" DROP COLUMN "posto";
+ALTER TABLE "escalas" RENAME COLUMN "posto_new" TO "posto";

--- a/backend-app/prisma/schema.prisma
+++ b/backend-app/prisma/schema.prisma
@@ -74,9 +74,9 @@ model MembroGuarnicao {
 }
 
 model Escala {
-  id                String @id @default(uuid())
+  id                String     @id @default(uuid())
   membroGuarnicaoId String
-  posto             String
+  posto             SetorLocal
   turno             Int
   inicioPrimeiroHorario String?
   fimTerceiroHorario    String?

--- a/backend-app/src/constants/sped.ts
+++ b/backend-app/src/constants/sped.ts
@@ -22,6 +22,13 @@ export const MESES_PT = [
 
 export const LOCAL_QUARTEL = "Quartel da Praia Vermelha"
 
+export const SETOR_LOCAL_LABELS: Record<string, string> = {
+  ALA_5_PISO: "Ala 5° Piso",
+  ALA_4_PISO: "4° Piso",
+  ALA_3_PISO: "3° Piso",
+  SEG_FEM: "Seg Fem",
+}
+
 export const VALOR_AUSENTE = "S/A"
 
 export const SPED_SECOES = {

--- a/backend-app/src/schemas/escalas.schemas.ts
+++ b/backend-app/src/schemas/escalas.schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { SetorLocal } from "@prisma/client";
 
 type DefinedPartial<T> = {
   [K in keyof T]?: Exclude<T[K], undefined>;
@@ -46,7 +47,7 @@ const membroGuarnicaoOpcionalSchema = z.preprocess(
 );
 
 export const configurarEscalaSchema = z.object({
-  posto: z.string().trim().min(1, "Informe o posto"),
+  posto: z.nativeEnum(SetorLocal),
   inicioPrimeiroHorario: horarioOpcionalSchema,
   fimTerceiroHorario: horarioOpcionalSchema,
   alocacoes: z
@@ -84,7 +85,7 @@ export const escalaIdParamSchema = z.object({
 });
 
 export const postoParamSchema = z.object({
-  posto: z.string().trim().min(1, "Informe o posto"),
+  posto: z.nativeEnum(SetorLocal),
 });
 
 export const listarEscalasPorPostoQuerySchema = z.object({

--- a/backend-app/src/services/escalas.service.ts
+++ b/backend-app/src/services/escalas.service.ts
@@ -1,4 +1,5 @@
 import type { Prisma } from "@prisma/client";
+import { SetorLocal } from "@prisma/client";
 import { prisma } from "../lib/prisma.js";
 import type {
   AtualizarEscalaInput,
@@ -10,7 +11,7 @@ import type {
 export interface EscalaLinhaView {
   id: string;
   membroGuarnicaoId: string;
-  posto: string;
+  posto: SetorLocal;
   turno: number;
   horario: string;
   aluno: string;
@@ -433,16 +434,11 @@ export const configurarEscalaService = async (
 };
 
 export const listarEscalasPorPostoService = async (
-  posto: string,
+  posto: SetorLocal,
   servicoId?: ListarEscalasPorPostoQuery["servicoId"],
 ): Promise<EscalaLinhaView[]> => {
   const escalas = await prisma.escala.findMany({
-    where: {
-      posto: {
-        equals: posto,
-        mode: "insensitive",
-      },
-    },
+    where: { posto },
     include: {
       membroGuarnicao: {
         include: {

--- a/backend-app/src/services/sped.service.ts
+++ b/backend-app/src/services/sped.service.ts
@@ -4,7 +4,7 @@ import type { AtualizarSpedInput } from "../schemas/speds.schemas.js"
 import { buscarAlteracoesPorServico } from "./alteracao.service.js"
 import { listarServicoAtualService } from "./servicos.service.js"
 import { INSTALACOES_POR_COMPANHIA, TEXTO_PENDENTES } from "../constants/instalacoes.js"
-import { LOCAL_QUARTEL, SPED_SECOES, VALOR_AUSENTE } from "../constants/sped.js"
+import { LOCAL_QUARTEL, SETOR_LOCAL_LABELS, SPED_SECOES, VALOR_AUSENTE } from "../constants/sped.js"
 import { funcaoLabel, formatDatePt, postoRank, safeValue } from "../utils/sped.utils.js"
 
 export const obterOuCriarSpedService = async (
@@ -85,7 +85,7 @@ export const gerarTextoAlunosService = async (
     if (!ano) continue
     const func = funcaoLabel(membro.funcao)
     const postoRaw = membro.escalas?.[0]?.posto
-    const postoDisplay = postoRaw ?? "Sem posto"
+    const postoDisplay = postoRaw ? (SETOR_LOCAL_LABELS[postoRaw] ?? postoRaw) : "Sem posto"
     const key = `${func} ${postoDisplay}`
     const lista = groups.get(key) ?? []
     const item: { nome: string; ano: number; curso?: string } = { nome: membro.aluno.nomeGuerra, ano }

--- a/backend-app/src/utils/sped.utils.ts
+++ b/backend-app/src/utils/sped.utils.ts
@@ -4,13 +4,13 @@ export const funcaoLabel = (funcao: string): string =>
   FUNCAO_LABELS[funcao] ?? funcao
 
 export const postoRank = (postoRaw?: string): number => {
-  if (!postoRaw) return 4
-  const s = postoRaw.toLowerCase()
-  if (s.includes("3")) return 0
-  if (s.includes("4")) return 1
-  if (s.includes("5")) return 2
-  if (s.includes("aloj") && s.includes("fem")) return 3
-  return 4
+  switch (postoRaw) {
+    case "ALA_3_PISO": return 0
+    case "ALA_4_PISO": return 1
+    case "ALA_5_PISO": return 2
+    case "SEG_FEM":    return 3
+    default:           return 4
+  }
 }
 
 export const formatDatePt = (d?: Date | string | null): string => {

--- a/frontend-app/src/components/pages/escalas/ConfigurarPostoModal.tsx
+++ b/frontend-app/src/components/pages/escalas/ConfigurarPostoModal.tsx
@@ -1,15 +1,17 @@
 import { Search, X } from 'lucide-react';
 import { Button } from '../../../components/ui/Button';
 import { Input } from '../../../components/ui/Input';
+import type { SetorLocal } from '../../../constants/setor-local';
+import { SETOR_LOCAL_LABELS } from '../../../constants/setor-local';
 import type { AlocacaoFormRow, MembroEscalaOption } from '../../../types/escala.types';
 import { obterDescricaoTurno } from '../../../utils/turno';
 import { labelDoMembro } from '../../../utils/escala.helpers';
 
 interface ConfigurarPostoModalProps {
   isOpen: boolean;
-  postos: string[];
-  postoSelecionado: string;
-  onPostoChange: (posto: string) => void;
+  postos: SetorLocal[];
+  postoSelecionado: SetorLocal;
+  onPostoChange: (posto: SetorLocal) => void;
   inicioPrimeiroHorario: string;
   fimTerceiroHorario: string;
   onInicioPrimeiroHorarioChange: (horario: string) => void;
@@ -65,12 +67,12 @@ export const ConfigurarPostoModal = ({
             <select
               id="posto-select"
               value={postoSelecionado}
-              onChange={(event) => onPostoChange(event.target.value)}
+              onChange={(event) => onPostoChange(event.target.value as SetorLocal)}
               className="h-12 w-full rounded-xl border border-slate-300 px-4 text-slate-700 focus:border-blue-500 focus:outline-none"
             >
               {postos.map((posto) => (
                 <option key={posto} value={posto}>
-                  {posto}
+                  {SETOR_LOCAL_LABELS[posto]}
                 </option>
               ))}
             </select>

--- a/frontend-app/src/components/pages/escalas/PostoTabs.tsx
+++ b/frontend-app/src/components/pages/escalas/PostoTabs.tsx
@@ -1,7 +1,10 @@
+import type { SetorLocal } from '../../../constants/setor-local';
+import { SETOR_LOCAL_LABELS } from '../../../constants/setor-local';
+
 interface PostoTabsProps {
-  postos: string[];
-  activePosto: string;
-  onSelect: (posto: string) => void;
+  postos: SetorLocal[];
+  activePosto: SetorLocal;
+  onSelect: (posto: SetorLocal) => void;
   className?: string;
 }
 
@@ -28,7 +31,7 @@ export const PostoTabs = ({
                   : 'border-transparent text-slate-500 hover:text-slate-700'
               }`}
             >
-              {posto}
+              {SETOR_LOCAL_LABELS[posto]}
             </button>
           );
         })}

--- a/frontend-app/src/constants/setor-local.ts
+++ b/frontend-app/src/constants/setor-local.ts
@@ -1,0 +1,22 @@
+export const SetorLocal = {
+  ALA_5_PISO: 'ALA_5_PISO',
+  ALA_4_PISO: 'ALA_4_PISO',
+  ALA_3_PISO: 'ALA_3_PISO',
+  SEG_FEM: 'SEG_FEM',
+} as const;
+
+export type SetorLocal = (typeof SetorLocal)[keyof typeof SetorLocal];
+
+export const SETOR_LOCAL_LABELS: Record<SetorLocal, string> = {
+  ALA_5_PISO: 'Ala 5° Piso',
+  ALA_4_PISO: '4° Piso',
+  ALA_3_PISO: '3° Piso',
+  SEG_FEM: 'SegFem',
+};
+
+export const POSTOS_ORDENADOS: SetorLocal[] = [
+  SetorLocal.ALA_5_PISO,
+  SetorLocal.ALA_4_PISO,
+  SetorLocal.ALA_3_PISO,
+  SetorLocal.SEG_FEM,
+];

--- a/frontend-app/src/hooks/useEscalaViewModel.ts
+++ b/frontend-app/src/hooks/useEscalaViewModel.ts
@@ -23,6 +23,7 @@ import {
   montarPayloadConfiguracao,
   POSTOS_INICIAIS,
 } from '../utils/escala.helpers';
+import type { SetorLocal } from '../constants/setor-local';
 import { gerarPdfEscala } from '../utils/escalaPdf';
 import {
   FIM_TERCEIRO_HORARIO_PADRAO,
@@ -32,9 +33,9 @@ import {
 
 export const useEscalaViewModel = () => {
   const queryClient = useQueryClient();
-  const [postoAtivo, setPostoAtivo] = useState<string>(POSTOS_INICIAIS[0]);
+  const [postoAtivo, setPostoAtivo] = useState<SetorLocal>(POSTOS_INICIAIS[0]);
   const [modalAberto, setModalAberto] = useState(false);
-  const [postoModal, setPostoModal] = useState<string>(POSTOS_INICIAIS[0]);
+  const [postoModal, setPostoModal] = useState<SetorLocal>(POSTOS_INICIAIS[0]);
   const [erroModal, setErroModal] = useState<string | null>(null);
   const [alocacoes, setAlocacoes] = useState<AlocacaoFormRow[]>(criarAlocacoesIniciais);
   const [inicioPrimeiroHorario, setInicioPrimeiroHorario] = useState<string>(
@@ -66,7 +67,7 @@ export const useEscalaViewModel = () => {
   });
 
   const postos = useMemo(() => {
-    const lista = new Set<string>(POSTOS_INICIAIS);
+    const lista = new Set<SetorLocal>(POSTOS_INICIAIS);
     (escalasQuery.data ?? []).forEach((linha) => lista.add(linha.posto));
     lista.add(postoModal);
     return [...lista];
@@ -151,11 +152,6 @@ export const useEscalaViewModel = () => {
   };
 
   const salvarConfiguracao = () => {
-    if (!postoModal.trim()) {
-      setErroModal('Selecione um posto antes de salvar.');
-      return;
-    }
-
     if (alocacoes.length === 0) {
       setErroModal('Adicione pelo menos uma alocacao.');
       return;

--- a/frontend-app/src/services/escalas.service.ts
+++ b/frontend-app/src/services/escalas.service.ts
@@ -1,4 +1,5 @@
 import { api } from './api';
+import type { SetorLocal } from '../constants/setor-local';
 import type {
   AtualizarEscalaPayload,
   BuscarMembrosEscalaParams,
@@ -23,7 +24,7 @@ export const configurarPostoEscalaService = async (
 };
 
 export const listarEscalasPorPostoService = async (
-  posto: string,
+  posto: SetorLocal,
 ): Promise<EscalaLinha[]> => {
   const response = await api.get(`/escalas/${encodeURIComponent(posto)}`);
   return response.data;

--- a/frontend-app/src/types/escala.types.ts
+++ b/frontend-app/src/types/escala.types.ts
@@ -1,9 +1,13 @@
+import type { SetorLocal } from '../constants/setor-local';
+
+export type { SetorLocal } from '../constants/setor-local';
+
 export type CampoEditavel = 'quarto' | 'cama';
 
 export interface EscalaLinha {
   id: string;
   membroGuarnicaoId: string;
-  posto: string;
+  posto: SetorLocal;
   turno: number;
   horario: string;
   aluno: string;
@@ -20,7 +24,7 @@ export interface ConfigurarEscalaAlocacao {
 }
 
 export interface ConfigurarEscalaPayload {
-  posto: string;
+  posto: SetorLocal;
   inicioPrimeiroHorario?: string;
   fimTerceiroHorario?: string;
   alocacoes: ConfigurarEscalaAlocacao[];

--- a/frontend-app/src/utils/escala.helpers.ts
+++ b/frontend-app/src/utils/escala.helpers.ts
@@ -5,9 +5,11 @@ import type {
   InlineDraft,
   MembroEscalaOption,
 } from '../types/escala.types';
+import { POSTOS_ORDENADOS } from '../constants/setor-local';
+import type { SetorLocal } from '../constants/setor-local';
 import { TOTAL_TURNOS_ESCALA } from './turno';
 
-export const POSTOS_INICIAIS = ['Ala 5o Piso', '4o Piso', '3o Piso', 'SegFem'];
+export const POSTOS_INICIAIS: SetorLocal[] = POSTOS_ORDENADOS;
 
 export const criarAlocacoesIniciais = (): AlocacaoFormRow[] => {
   return Array.from({ length: TOTAL_TURNOS_ESCALA }, () => criarAlocacaoVazia());
@@ -65,13 +67,13 @@ export const criarInlineDrafts = (linhas: EscalaLinha[]): Record<string, InlineD
 };
 
 export const montarPayloadConfiguracao = (
-  posto: string,
+  posto: SetorLocal,
   alocacoes: AlocacaoFormRow[],
   inicioPrimeiroHorario?: string,
   fimTerceiroHorario?: string,
 ): ConfigurarEscalaPayload => {
   return {
-    posto: posto.trim(),
+    posto,
     inicioPrimeiroHorario: inicioPrimeiroHorario?.trim() || undefined,
     fimTerceiroHorario: fimTerceiroHorario?.trim() || undefined,
     alocacoes: alocacoes.map((alocacao, index) => ({

--- a/frontend-app/src/utils/escalaPdf.ts
+++ b/frontend-app/src/utils/escalaPdf.ts
@@ -1,10 +1,12 @@
 import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import type { EscalaLinha } from '../types/escala.types';
+import type { SetorLocal } from '../constants/setor-local';
+import { SETOR_LOCAL_LABELS } from '../constants/setor-local';
 import { gerarIntervaloPorTurno } from './turno';
 
 interface GerarPdfEscalaParams {
-  posto: string;
+  posto: SetorLocal;
   dataExtenso: string;
   linhas: EscalaLinha[];
 }
@@ -96,7 +98,7 @@ export const gerarPdfEscala = ({ posto, dataExtenso, linhas }: GerarPdfEscalaPar
 
   doc.setFontSize(11);
   doc.setTextColor(71, 85, 105);
-  doc.text(`Posto: ${posto}`, 40, 74);
+  doc.text(`Posto: ${SETOR_LOCAL_LABELS[posto]}`, 40, 74);
   doc.text(`Data: ${dataExtenso}`, 40, 92);
 
   const linhasTabela = montarLinhasTabelaPorHorario(linhas);
@@ -131,5 +133,5 @@ export const gerarPdfEscala = ({ posto, dataExtenso, linhas }: GerarPdfEscalaPar
     },
   });
 
-  doc.save(nomeArquivoSeguro(posto));
+  doc.save(nomeArquivoSeguro(SETOR_LOCAL_LABELS[posto]));
 };


### PR DESCRIPTION
## Resumo
- `Escala.posto` migrado de `String` para `SetorLocal` enum no Prisma schema
- Migration com conversão de dados legados (`'Ala 5o Piso'` → `ALA_5_PISO` etc.)
- Zod schemas validam o enum rigorosamente via `z.nativeEnum(SetorLocal)`
- Frontend ganha `constants/setor-local.ts` com o enum espelhado + labels de exibição
- Todos os tipos `string` de posto substituídos por `SetorLocal` em toda a stack

## Arquivos alterados
**Backend**
- `prisma/schema.prisma` — `posto String` → `posto SetorLocal`
- `prisma/migrations/20260615120000_escala_posto_enum/` — data migration
- `src/schemas/escalas.schemas.ts` — `z.nativeEnum(SetorLocal)`
- `src/services/escalas.service.ts` — tipo `SetorLocal`, query sem `mode:insensitive`
- `src/constants/sped.ts` — `SETOR_LOCAL_LABELS` para exibição no SPED
- `src/utils/sped.utils.ts` — `postoRank` usa switch em enum keys
- `src/services/sped.service.ts` — `postoDisplay` usa label legível

**Frontend**
- `src/constants/setor-local.ts` — novo: `SetorLocal`, `SETOR_LOCAL_LABELS`, `POSTOS_ORDENADOS`
- `src/types/escala.types.ts` — `posto: SetorLocal`
- `src/services/escalas.service.ts` — `(posto: SetorLocal)`
- `src/utils/escala.helpers.ts` — `POSTOS_INICIAIS` usa `POSTOS_ORDENADOS`
- `src/utils/escalaPdf.ts` — exibe label no PDF
- `src/components/pages/escalas/PostoTabs.tsx` — renderiza `SETOR_LOCAL_LABELS[posto]`
- `src/components/pages/escalas/ConfigurarPostoModal.tsx` — select usa labels
- `src/hooks/useEscalaViewModel.ts` — estados tipados como `SetorLocal`

## Checklist
- [x] Typecheck backend passa
- [x] Typecheck frontend passa
- [x] Lint passa
- [x] Migration executada e verificada no banco