### PR TITLE
feat(alteracoes): persist checkbox verificada e label dinamico por comodo

### DIFF
--- a/backend-app/prisma/migrations/20260616130000_add_verificada_to_alteracao/migration.sql
+++ b/backend-app/prisma/migrations/20260616130000_add_verificada_to_alteracao/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "alteracoes" ADD COLUMN "verificada" BOOLEAN NOT NULL DEFAULT false;

--- a/backend-app/prisma/schema.prisma
+++ b/backend-app/prisma/schema.prisma
@@ -120,6 +120,7 @@ model Alteracao {
   descricao String
   fotoUrl   String?
   status    StatusAlteracao @default(NOVA)
+  verificada Boolean        @default(false)
   criadoEm  DateTime        @default(now())
 
   // Relacionamentos

--- a/backend-app/src/controllers/alteracao.controller.ts
+++ b/backend-app/src/controllers/alteracao.controller.ts
@@ -4,14 +4,17 @@ import {
 	alteracaoIdParamSchema,
 	atualizarAlteracaoSchema,
 	atualizarStatusAlteracaoSchema,
+	verificarAlteracaoSchema,
 	listarAlteracoesQuerySchema,
 	criarAlteracaoSchema,
 	type AtualizarStatusAlteracaoInput,
 	type AtualizarAlteracaoInput,
+	type VerificarAlteracaoInput,
 } from "../schemas/alteracao.schemas.js";
 import {
 	atualizarAlteracao,
 	atualizarStatusAlteracao,
+	verificarAlteracao,
 	criarAlteracao,
 	listarAlteracoes,
 	deletarAlteracao,
@@ -122,6 +125,17 @@ return responderAtualizacaoDaAlteracao(
 	"Erro ao atualizar alteração: ",
 	"Erro interno do servidor ao atualizar alteração",
 );
+};
+
+export const verificarAlteracaoController = async (req: Request, res: Response) => {
+	return responderAtualizacaoDaAlteracao(
+		req,
+		res,
+		verificarAlteracaoSchema,
+		async (id, dados) => verificarAlteracao(id, dados as VerificarAlteracaoInput),
+		"Erro ao verificar alteração: ",
+		"Erro interno do servidor ao verificar alteração",
+	);
 };
 
 export const uploadFotoAlteracao = async (req: Request, res: Response) => {

--- a/backend-app/src/routes/alteracoes.routes.ts
+++ b/backend-app/src/routes/alteracoes.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import {
   atualizarDadosDaAlteracao,
   atualizarStatusDaAlteracao,
+  verificarAlteracaoController,
   criarNovaAlteracao,
   listarAlteracoesTodas,
   uploadFotoAlteracao,
@@ -16,6 +17,7 @@ router.post("/", criarNovaAlteracao);
 router.post("/upload", uploadImagem.single("foto"), uploadFotoAlteracao);
 router.patch("/:id", atualizarDadosDaAlteracao);
 router.patch("/:id/status", atualizarStatusDaAlteracao);
+router.patch("/:id/verificar", verificarAlteracaoController);
 router.delete("/:id", removerAlteracao);
 
 export default router;

--- a/backend-app/src/schemas/alteracao.schemas.ts
+++ b/backend-app/src/schemas/alteracao.schemas.ts
@@ -42,5 +42,11 @@ export const atualizarAlteracaoSchema = z
 
 export type AtualizarAlteracaoInput = z.infer<typeof atualizarAlteracaoSchema>;
 
+export const verificarAlteracaoSchema = z.object({
+  verificada: z.boolean(),
+});
+
+export type VerificarAlteracaoInput = z.infer<typeof verificarAlteracaoSchema>;
+
 
 

--- a/backend-app/src/services/alteracao.service.ts
+++ b/backend-app/src/services/alteracao.service.ts
@@ -4,6 +4,7 @@ import type {
   AtualizarAlteracaoInput,
   CriarAlteracaoInput,
   ListarAlteracoesQueryInput,
+  VerificarAlteracaoInput,
 } from "../schemas/alteracao.schemas.js"
 
 
@@ -91,6 +92,25 @@ export const atualizarAlteracao = async (
   return prisma.alteracao.update({
     where: { id },
     data: dadosParaAtualizacao,
+  })
+}
+
+export const verificarAlteracao = async (
+  id: string,
+  dados: VerificarAlteracaoInput,
+): Promise<Alteracao> => {
+  const alteracaoExistente = await prisma.alteracao.findUnique({
+    where: { id },
+    select: { id: true },
+  })
+
+  if (!alteracaoExistente) {
+    throw new Error("ALTERACAO_NAO_ENCONTRADA")
+  }
+
+  return prisma.alteracao.update({
+    where: { id },
+    data: { verificada: dados.verificada },
   })
 }
 

--- a/frontend-app/src/components/pages/Alteracoes/DetalhesAlteracao.tsx
+++ b/frontend-app/src/components/pages/Alteracoes/DetalhesAlteracao.tsx
@@ -5,9 +5,15 @@ type DetalhesAlteracaoProps = {
   alteracao: Alteracao
   abrirModalEdicaoAlteracao: (alteracao: Alteracao) => void
   handleResolverAlteracao: (id: string) => Promise<void>
+  handleToggleVerificada: (id: string, verificada: boolean) => Promise<void>
 }
 
-export const DetalhesAlteracao = ({ alteracao, abrirModalEdicaoAlteracao, handleResolverAlteracao }: DetalhesAlteracaoProps) => {
+export const DetalhesAlteracao = ({
+  alteracao,
+  abrirModalEdicaoAlteracao,
+  handleResolverAlteracao,
+  handleToggleVerificada,
+}: DetalhesAlteracaoProps) => {
   return (
     <div key={alteracao.id} className="flex gap-6">
       <div className="w-40 h-40 bg-slate-200 rounded-lg flex items-center justify-center text-slate-400 text-sm font-medium shrink-0 overflow-hidden">
@@ -27,7 +33,6 @@ export const DetalhesAlteracao = ({ alteracao, abrirModalEdicaoAlteracao, handle
         <p className="text-slate-700 font-medium">{alteracao.descricao}</p>
 
         <div className="flex flex-col gap-3">
-          
           <button
             className="px-4 py-1.5 border border-slate-200 text-slate-600 text-sm font-medium rounded-lg hover:bg-slate-50 transition-colors"
             onClick={(e) => {
@@ -43,11 +48,16 @@ export const DetalhesAlteracao = ({ alteracao, abrirModalEdicaoAlteracao, handle
             <label className="flex items-center gap-2 cursor-pointer">
               <input
                 type="checkbox"
-                className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                checked={alteracao.verificada}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  void handleToggleVerificada(alteracao.id, e.target.checked)
+                }}
+                className="w-4 h-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500 cursor-pointer"
               />
               <span className="text-sm text-slate-600">Alteração Verificada</span>
             </label>
-  
+
             <div>
               <button
                 className="mt-2 px-4 py-1.5 border-2 border-emerald-500 text-emerald-600 text-sm font-medium rounded-lg hover:bg-emerald-50 transition-colors"
@@ -63,6 +73,5 @@ export const DetalhesAlteracao = ({ alteracao, abrirModalEdicaoAlteracao, handle
         </div>
       </div>
     </div>
-
   )
 }

--- a/frontend-app/src/components/pages/Alteracoes/toggleQuarto.tsx
+++ b/frontend-app/src/components/pages/Alteracoes/toggleQuarto.tsx
@@ -24,6 +24,7 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
     abrirModalEdicaoAlteracao,
     fecharModalAlteracao,
     handleResolverAlteracao,
+    handleToggleVerificada,
   } = useToggleQuarto(comodos[0]?.id)
 
   return (
@@ -31,9 +32,8 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
       {comodos.map((comodo) => {
         const isExpandido = quartosExpandidos.includes(comodo.id);
         const alteracoesComodo = alteracoes.filter((item) => item.comodo === comodo.id && item.status !== "RESOLVIDA");
-        const status = alteracoesComodo.some((item) => item.status !== "RESOLVIDA")
-          ? "Pendente"
-          : "Verificado";
+        const todasVerificadas = alteracoesComodo.length === 0 || alteracoesComodo.every((item) => item.verificada);
+        const status = todasVerificadas ? "Verificado" : "Pendente";
 
         return (
           <div
@@ -81,11 +81,12 @@ export const ToggleQuarto = ({ comodos, alteracoes, setor, onCreated }: ToggleQu
                 )}
 
                 {alteracoesComodo.map((alteracao) => (
-                  <DetalhesAlteracao 
-                    alteracao={alteracao} 
+                  <DetalhesAlteracao
+                    key={alteracao.id}
+                    alteracao={alteracao}
                     abrirModalEdicaoAlteracao={abrirModalEdicaoAlteracao}
                     handleResolverAlteracao={handleResolverAlteracao}
-                    key={alteracao.id}
+                    handleToggleVerificada={handleToggleVerificada}
                   />
                 ))}
               </div>

--- a/frontend-app/src/hooks/useToggleQuarto.ts
+++ b/frontend-app/src/hooks/useToggleQuarto.ts
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { atualizarStatusAlteracao } from "../services/alteracao.service"
+import { atualizarStatusAlteracao, verificarAlteracao } from "../services/alteracao.service"
 import { useQueryClient } from "@tanstack/react-query"
 import type { Alteracao } from "../types/alterecao.types"
 
@@ -44,6 +44,18 @@ export const useToggleQuarto = (initialExpandedComodoId?: string) => {
     await queryClient.invalidateQueries({ queryKey: ["alteracoesAtuais"] })
   }
 
+  const handleToggleVerificada = async (alteracaoId: string, verificada: boolean) => {
+    queryClient.setQueryData<Alteracao[]>(["alteracoesAtuais"], (atual) =>
+      atual?.map((a) => (a.id === alteracaoId ? { ...a, verificada } : a)),
+    )
+
+    const resultado = await verificarAlteracao(alteracaoId, verificada)
+
+    if (!resultado) {
+      await queryClient.invalidateQueries({ queryKey: ["alteracoesAtuais"] })
+    }
+  }
+
   return {
     quartosExpandidos,
     isModalOpen,
@@ -54,5 +66,6 @@ export const useToggleQuarto = (initialExpandedComodoId?: string) => {
     abrirModalEdicaoAlteracao,
     fecharModalAlteracao,
     handleResolverAlteracao,
+    handleToggleVerificada,
   }
 }

--- a/frontend-app/src/services/alteracao.service.ts
+++ b/frontend-app/src/services/alteracao.service.ts
@@ -101,6 +101,19 @@ export async function atualizarStatusAlteracao(
   }
 }
 
+export const verificarAlteracao = async (
+  alteracaoId: string,
+  verificada: boolean,
+): Promise<Alteracao | null> => {
+  try {
+    const response = await api.patch(`/alteracoes/${alteracaoId}/verificar`, { verificada })
+    return response.data ?? null
+  } catch (error) {
+    console.error("Erro ao verificar alteração: ", error)
+    return null
+  }
+}
+
 export const removerAlteracao = async (alteracaoId: string): Promise<boolean> => {
   try {
     await api.delete(`/alteracoes/${alteracaoId}`)

--- a/frontend-app/src/types/alterecao.types.ts
+++ b/frontend-app/src/types/alterecao.types.ts
@@ -9,6 +9,7 @@ export interface Alteracao {
   fotoUrl: string | null,
   comodo: string,
   status: StatusAlteracao,
+  verificada: boolean,
 }
 
 export interface CriarAlteracaoInput {


### PR DESCRIPTION
## Resumo
- Adiciona campo `verificada` (boolean, default false) na tabela `alteracoes` via migration
- Novo endpoint `PATCH /alteracoes/:id/verificar` para persistir estado da checkbox
- Frontend: checkbox com update otimista + sincronização via API; estado persiste entre sessões
- Label do cômodo muda para **Verificado** quando todas as alterações não-resolvidas estão verificadas

## Checklist
- [x] Typecheck passa
- [x] Lint passa
- [x] Migration aplicada e registrada no banco